### PR TITLE
docs: curate ops content 2026-05-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [DeepEval](https://github.com/confident-ai/deepeval): LLM evaluation framework for testing RAG, agents, and model outputs in CI or production workflows.
 - [Ragas](https://github.com/explodinggradients/ragas): Evaluation framework for RAG pipelines and LLM applications.
 - [LiteLLM](https://github.com/BerriAI/litellm): OpenAI-compatible LLM gateway with routing, budgets, logging, and provider abstraction.
+- [OpenLIT](https://github.com/openlit/openlit): OpenTelemetry-native AI engineering platform for LLM observability, evaluations, guardrails, prompt management, and GPU monitoring.
 
 ## AIOps
 
@@ -87,6 +88,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [kubecost](https://kubecost.com/): Kubernetes cost management and monitoring platform.
 - [OpenCost](https://opencost.io/): Open-source tool for tracking and allocating cloud costs in Kubernetes environments.
 - [Infracost](https://github.com/infracost/infracost): Cloud cost forecasting tool for Terraform and Kubernetes cost estimates.
+- [OptScale](https://github.com/hystax/optscale): Open-source FinOps and cloud cost optimization platform for AWS, Azure, GCP, Alibaba Cloud, and Kubernetes.
 - [KubeStellar Console](https://github.com/kubestellar/console): Multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and CNCF project integrations across edge and cloud clusters.
 
 ## Observability

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,6 +59,7 @@
 - [DeepEval](https://github.com/confident-ai/deepeval)：LLM 评估框架，适合在 CI 或生产流程中测试 RAG、Agent 和模型输出。
 - [Ragas](https://github.com/explodinggradients/ragas)：面向 RAG 流水线和 LLM 应用的评估框架。
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。
+- [OpenLIT](https://github.com/openlit/openlit)：基于 OpenTelemetry 的 AI 工程平台，支持 LLM 可观测性、评估、护栏、Prompt 管理和 GPU 监控。
 
 ## AIOps 智能运维
 
@@ -87,6 +88,7 @@
 - [kubecost](https://kubecost.com/)：Kubernetes 成本管理与监控工具。
 - [OpenCost](https://opencost.io/)：开源工具，用于跟踪和分摊 Kubernetes 环境中的云成本。
 - [Infracost](https://github.com/infracost/infracost)：云成本预测工具，支持 Terraform 和 Kubernetes 成本估算。
+- [OptScale](https://github.com/hystax/optscale)：开源 FinOps 与云成本优化平台，支持 AWS、Azure、GCP、阿里云和 Kubernetes。
 - [KubeStellar Console](https://github.com/kubestellar/console)：多集群 Kubernetes 控制台，提供 AI 辅助运维、实时可观测性和边缘/云集群管理能力。
 
 ## Observability 可观测性


### PR DESCRIPTION
## Summary
- Add two high-quality X-Ops projects to the English and Simplified Chinese READMEs.
- Keep entries scoped to LLM observability and FinOps/cloud cost optimization.

## Projects or content added
- OpenLIT: OpenTelemetry-native AI engineering platform for LLM observability, evaluations, guardrails, prompt management, and GPU monitoring.
- OptScale: Open-source FinOps and cloud cost optimization platform for AWS, Azure, GCP, Alibaba Cloud, and Kubernetes.

## Validation
- Markdown structural checks passed for README.md and README.zh-CN.md.
- New entry parity check passed for both language variants.
- `git diff --check` passed.
- Changed files are limited to README.md and README.zh-CN.md.
- Branch was rebased onto latest origin/main and freshness verified before push.

## Risk
- Low: documentation-only curation update.
- Main curation risk is adding entries that later become stale; both candidates currently show active maintenance and clear ecosystem fit.

## Auto-merge intent
- Auto-merge is allowed if PR diff review remains clean and checks are green or absent.
