### PR TITLE
docs: curate Kubernetes operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 - [Cilium](https://github.com/cilium/cilium): eBPF-based Kubernetes networking, security, and observability platform.
 - [Karpenter](https://github.com/kubernetes-sigs/karpenter): Flexible Kubernetes node autoscaler for improving cluster efficiency and workload scheduling.
+- [cert-manager](https://github.com/cert-manager/cert-manager): Kubernetes-native certificate management controller for issuing and renewing TLS certificates.
+- [External Secrets Operator](https://github.com/external-secrets/external-secrets): Kubernetes operator that syncs secrets from external secret managers into Kubernetes Secrets.
+- [KEDA](https://github.com/kedacore/keda): Kubernetes event-driven autoscaler for scaling workloads from external metrics and event sources.
 
 ## Security and Supply Chain
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,6 +101,9 @@
 
 - [Cilium](https://github.com/cilium/cilium)：基于 eBPF 的 Kubernetes 网络、安全和可观测性平台。
 - [Karpenter](https://github.com/kubernetes-sigs/karpenter)：灵活的 Kubernetes 节点自动扩缩容工具，用于提升集群效率和调度效果。
+- [cert-manager](https://github.com/cert-manager/cert-manager)：Kubernetes 原生证书管理控制器，用于签发和续期 TLS 证书。
+- [External Secrets Operator](https://github.com/external-secrets/external-secrets)：Kubernetes Operator，可将外部 Secret 管理系统中的密钥同步为 Kubernetes Secrets。
+- [KEDA](https://github.com/kedacore/keda)：Kubernetes 事件驱动自动伸缩器，可基于外部指标和事件源扩缩容工作负载。
 
 ## Security and Supply Chain 安全与供应链
 


### PR DESCRIPTION
## Summary
- Add three mature Kubernetes operations projects to the curated X-Ops map.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- cert-manager: Kubernetes-native TLS certificate management.
- External Secrets Operator: syncs external secret manager data into Kubernetes Secrets.
- KEDA: event-driven autoscaling for Kubernetes workloads.

## Validation
- Markdown structural checks: passed.
- Bilingual new-entry parity check: passed.
- Duplicate URL/name check: passed.
- Rebased onto latest origin/main before push.
- Changed files limited to README.md and README.zh-CN.md.

## Risk
- Low: documentation-only curation change.
- Main risk is category noise; selected projects are established Kubernetes operations tools with active maintenance and broad adoption.

## Auto-merge intent
- Auto-merge is allowed only if PR diff remains docs-only and checks are green or absent.
