### PR TITLE
docs: add abtop to LLM observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix): Open-source observability and evaluation platform for LLM, RAG, and ML systems.
 - [Helicone](https://github.com/Helicone/helicone): Open-source observability platform for LLM usage, latency, cost, caching, and request logs.
 - [agenttrace](https://github.com/luoyuctl/agenttrace): Local-first TUI for inspecting AI coding agent cost, tokens, latency, failures, and reports.
+- [abtop](https://github.com/graykode/abtop): htop-style terminal monitor for AI coding agent sessions, tokens, context windows, rate limits, and ports.
 - [DeepEval](https://github.com/confident-ai/deepeval): LLM evaluation framework for testing RAG, agents, and model outputs in CI or production workflows.
 - [Ragas](https://github.com/explodinggradients/ragas): Evaluation framework for RAG pipelines and LLM applications.
 - [LiteLLM](https://github.com/BerriAI/litellm): OpenAI-compatible LLM gateway with routing, budgets, logging, and provider abstraction.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,6 +57,7 @@
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix)：面向 LLM、RAG 和机器学习系统的开源可观测与评估平台。
 - [Helicone](https://github.com/Helicone/helicone)：开源 LLM 可观测平台，支持用量、延迟、成本、缓存和请求日志分析。
 - [agenttrace](https://github.com/luoyuctl/agenttrace)：本地优先的 TUI，用于检查 AI 编码 Agent 的成本、Token、延迟、失败和报告。
+- [abtop](https://github.com/graykode/abtop)：类似 htop 的终端监控工具，用于查看 AI 编码 Agent 会话、Token、上下文窗口、速率限制和端口。
 - [DeepEval](https://github.com/confident-ai/deepeval)：LLM 评估框架，适合在 CI 或生产流程中测试 RAG、Agent 和模型输出。
 - [Ragas](https://github.com/explodinggradients/ragas)：面向 RAG 流水线和 LLM 应用的评估框架。
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。


### PR DESCRIPTION
## Summary
- Add `graykode/abtop` to the LLM and Agent Observability section.
- Keep English and Simplified Chinese README entries aligned.

## Issue
Closes #12

## Validation
- Verified the project repository is active, MIT licensed, recently released, and relevant to AI coding agent observability.
- Ran markdown structural checks for internal links, duplicate URLs, and duplicate entry names.
- Verified `README.md` and `README.zh-CN.md` both include the new entry.
- Confirmed only README files changed and `origin/main` is an ancestor of the branch HEAD.

## Risk
- Low: documentation-only change.
- The project is relatively new, so future curation may revisit placement if its scope changes.
