### PR TITLE
docs: add Harness from issue #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ A curated technology stack and toolchain for platform engineering.
 ### CI/CD
 
 - [argo-workflows](https://github.com/argoproj/argo-workflows): Kubernetes-native workflow engine.
+- [Harness](https://github.com/harness/harness): Open-source end-to-end developer platform for source control, CI/CD pipelines, hosted development environments, and artifact registries.
 - [argo-cd](https://argo-cd.readthedocs.io/): Popular declarative GitOps CD tool for Kubernetes.
 - [Flux](https://fluxcd.io/): Popular Kubernetes GitOps toolkit.
 - [Apache Airflow](https://airflow.apache.org/): Open-source workflow orchestration platform for data pipelines.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -131,6 +131,7 @@
 ### CI/CD
 
 - [argo-workflows](https://github.com/argoproj/argo-workflows)：Kubernetes 原生工作流引擎。
+- [Harness](https://github.com/harness/harness)：开源端到端开发者平台，支持源码管理、CI/CD 流水线、托管开发环境和制品仓库。
 - [argo-cd](https://argo-cd.readthedocs.io/)：流行的 Kubernetes 声明式 GitOps CD 工具。
 - [Flux](https://fluxcd.io/)：流行的 Kubernetes GitOps 工具包。
 - [Apache Airflow](https://airflow.apache.org/)：开源工作流编排平台，常用于数据流水线。


### PR DESCRIPTION
## Summary
- Adds Harness to the CI/CD section in both English and Simplified Chinese READMEs.
- Uses the canonical GitHub repository link and keeps the description focused on its open-source developer platform scope.

## Issue
Closes #14

## Validation
- Markdown structural checks passed for README.md and README.zh-CN.md.
- Duplicate URL and duplicate entry-name checks passed.
- Internal Markdown link checks passed.
- Rebased/fresh against origin/main before PR creation.

## Risk
- Low docs-only change; main curation risk is category fit because the issue suggested LLM and Agent Observability, but Harness is better scoped under CI/CD/developer platform.