### PR TITLE
docs: curate ops content 2026-05-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 - [Dagster](https://dagster.io/): Data orchestration platform for modeling data assets and managing the data lifecycle.
 - [Apache NiFi](https://nifi.apache.org/): Visual dataflow orchestration for routing, transforming, and coordinating data across systems.
+- [DataHub](https://github.com/datahub-project/datahub): Metadata platform for data discovery, lineage, governance, and observability across modern data and AI stacks.
+- [Great Expectations](https://github.com/great-expectations/great_expectations): Data quality framework for validating datasets, documenting expectations, and catching pipeline regressions.
 
 ## FinOps
 
@@ -111,6 +113,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 - [Falco](https://github.com/falcosecurity/falco): CNCF runtime security tool for detecting suspicious behavior in containers and Kubernetes.
 - [Kyverno](https://github.com/kyverno/kyverno): Kubernetes-native policy engine for validation, mutation, generation, and image verification.
+- [Syft](https://github.com/anchore/syft): CLI and library for generating SBOMs from container images and filesystems.
+- [Grype](https://github.com/anchore/grype): Vulnerability scanner for container images and filesystems that works well with Syft-generated SBOMs.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,6 +84,8 @@
 
 - [Dagster](https://dagster.io/)：数据编排平台，支持数据资产建模和全生命周期管理。
 - [Apache NiFi](https://nifi.apache.org/)：可视化数据流编排工具，支持数据路由、转换和系统间协调。
+- [DataHub](https://github.com/datahub-project/datahub)：面向现代数据与 AI 技术栈的元数据平台，支持数据发现、血缘、治理和可观测性。
+- [Great Expectations](https://github.com/great-expectations/great_expectations)：数据质量框架，用于验证数据集、记录数据期望并发现流水线回归。
 
 ## FinOps
 
@@ -111,6 +113,8 @@
 
 - [Falco](https://github.com/falcosecurity/falco)：CNCF 运行时安全工具，用于检测容器和 Kubernetes 中的可疑行为。
 - [Kyverno](https://github.com/kyverno/kyverno)：Kubernetes 原生策略引擎，支持校验、变更、生成和镜像验证。
+- [Syft](https://github.com/anchore/syft)：用于从容器镜像和文件系统生成 SBOM 的 CLI 与库。
+- [Grype](https://github.com/anchore/grype)：面向容器镜像和文件系统的漏洞扫描器，可与 Syft 生成的 SBOM 配合使用。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
- Add DataOps entries for metadata governance and data quality validation.
- Add supply-chain security entries for SBOM generation and vulnerability scanning.
- Keep English and Simplified Chinese READMEs aligned.

## Projects or content added
- DataHub — metadata platform for discovery, lineage, governance, and observability.
- Great Expectations — data quality validation framework.
- Syft — SBOM generation CLI/library.
- Grype — vulnerability scanner for images and filesystems.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- Bilingual parity check passed for all added projects.
- Diff scope limited to README.md and README.zh-CN.md.
- Branch rebased onto latest origin/main and origin/main is an ancestor of HEAD.
- output/ was not staged or committed.

## Risk
- Low: documentation-only curation update.
- Main curation risk is category drift; selected projects are established and directly fit DataOps or supply-chain security.

## Auto-merge intent
- Auto-merge is allowed if PR diff review remains clean and checks are green or absent.
