### PR TITLE
docs: add Kafka UI tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [DataHub](https://github.com/datahub-project/datahub): Metadata platform for data discovery, lineage, governance, and observability across modern data and AI stacks.
 - [Great Expectations](https://github.com/great-expectations/great_expectations): Data quality framework for validating datasets, documenting expectations, and catching pipeline regressions.
 
+### Streaming Operations
+
+- [Kafbat UI](https://github.com/kafbat/kafka-ui): Open-source web UI for managing Apache Kafka clusters, topics, consumers, schemas, and Kafka Connect.
+
 ## FinOps
 
 - [Infracost](https://github.com/infracost/infracost): Cloud cost forecasting tool for Terraform and Kubernetes cost estimates.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,6 +90,10 @@
 - [DataHub](https://github.com/datahub-project/datahub)：面向现代数据与 AI 技术栈的元数据平台，支持数据发现、血缘、治理和可观测性。
 - [Great Expectations](https://github.com/great-expectations/great_expectations)：数据质量框架，用于验证数据集、记录数据期望并发现流水线回归。
 
+### Streaming Operations 流式数据运维
+
+- [Kafbat UI](https://github.com/kafbat/kafka-ui)：开源 Web UI，用于管理 Apache Kafka 集群、Topic、消费者、Schema 和 Kafka Connect。
+
 ## FinOps
 
 - [Infracost](https://github.com/infracost/infracost)：云成本预测工具，支持 Terraform 和 Kubernetes 成本估算。


### PR DESCRIPTION
## Summary
- Adds a Streaming Operations subsection under DataOps.
- Adds Kafbat UI as the Kafka management UI requested in the issue.
- Updates both English and Simplified Chinese READMEs with equivalent content.

## Issue
Closes #20

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- Bilingual parity check confirmed Kafbat UI appears in both READMEs.
- Diff scope checked: README.md and README.zh-CN.md only.
- Branch rebased on latest origin/main and origin/main is an ancestor of HEAD.

## Risk
- Low: documentation-only change.
- The new Streaming Operations subsection may need future expansion if more Kafka/EventOps tools are added.