### PR TITLE
docs: curate DevSecOps supply-chain tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Syft](https://github.com/anchore/syft): CLI and library for generating SBOMs from container images and filesystems.
 - [Grype](https://github.com/anchore/grype): Vulnerability scanner for container images and filesystems that works well with Syft-generated SBOMs.
 - [Kubescape](https://github.com/kubescape/kubescape): Kubernetes security platform for risk analysis, compliance, misconfiguration scanning, and CI/CD or cluster checks.
+- [Gitleaks](https://github.com/gitleaks/gitleaks): Secrets scanner for detecting hardcoded credentials in Git repositories, files, and CI/CD workflows.
+- [cosign](https://github.com/sigstore/cosign): Sigstore tool for signing and verifying container images, blobs, and software artifacts with transparency log support.
+- [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator): GitHub Actions workflows for generating SLSA provenance for builds and release artifacts.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,9 @@
 - [Syft](https://github.com/anchore/syft)：用于从容器镜像和文件系统生成 SBOM 的 CLI 与库。
 - [Grype](https://github.com/anchore/grype)：面向容器镜像和文件系统的漏洞扫描器，可与 Syft 生成的 SBOM 配合使用。
 - [Kubescape](https://github.com/kubescape/kubescape)：Kubernetes 安全平台，支持风险分析、合规、错误配置扫描，以及 CI/CD 或集群检查。
+- [Gitleaks](https://github.com/gitleaks/gitleaks)：Secret 扫描工具，用于在 Git 仓库、文件和 CI/CD 流程中发现硬编码凭据。
+- [cosign](https://github.com/sigstore/cosign)：Sigstore 工具，用于签名和验证容器镜像、Blob 与软件制品，并支持透明日志。
+- [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator)：用于在 GitHub Actions 中为构建和发布制品生成 SLSA provenance 的工作流。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
- Add three mature DevSecOps / supply-chain security projects to the curated map.
- Keep README.md and README.zh-CN.md aligned with concise bilingual descriptions.

## Projects or content added
- Gitleaks: secrets scanning for repositories, files, and CI/CD workflows.
- cosign: Sigstore signing and verification for images and artifacts.
- SLSA GitHub Generator: SLSA provenance generation for GitHub Actions builds and releases.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- Bilingual project presence check passed for both READMEs.
- git diff --check passed.
- Diff scope limited to README.md and README.zh-CN.md.
- Branch rebased on latest origin/main and origin/main is an ancestor of HEAD.
- output/ was not staged or committed.

## Risk
- Low: documentation-only curation update.
- Main risk is category fit/noise; selected projects are mature, actively maintained, and directly relevant to DevSecOps and supply-chain operations.

## Auto-merge intent
- Auto-merge is allowed only if PR diff review remains clean and checks are green or absent.
