### PR TITLE
docs: add policy and runtime security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,13 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 - [Falco](https://github.com/falcosecurity/falco): CNCF runtime security tool for detecting suspicious behavior in containers and Kubernetes.
 - [Kyverno](https://github.com/kyverno/kyverno): Kubernetes-native policy engine for validation, mutation, generation, and image verification.
+- [Open Policy Agent](https://github.com/open-policy-agent/opa): General-purpose policy engine for policy-as-code across Kubernetes, CI/CD, APIs, and infrastructure.
+- [Gatekeeper](https://github.com/open-policy-agent/gatekeeper): Kubernetes admission controller that enforces OPA policies and audit constraints across clusters.
 - [Syft](https://github.com/anchore/syft): CLI and library for generating SBOMs from container images and filesystems.
 - [Grype](https://github.com/anchore/grype): Vulnerability scanner for container images and filesystems that works well with Syft-generated SBOMs.
 - [Kubescape](https://github.com/kubescape/kubescape): Kubernetes security platform for risk analysis, compliance, misconfiguration scanning, and CI/CD or cluster checks.
 - [Gitleaks](https://github.com/gitleaks/gitleaks): Secrets scanner for detecting hardcoded credentials in Git repositories, files, and CI/CD workflows.
+- [KubeArmor](https://github.com/kubearmor/KubeArmor): Kubernetes runtime security enforcement system for least-privilege workload hardening with LSM-based policies.
 - [cosign](https://github.com/sigstore/cosign): Sigstore tool for signing and verifying container images, blobs, and software artifacts with transparency log support.
 - [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator): GitHub Actions workflows for generating SLSA provenance for builds and release artifacts.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,10 +132,13 @@
 
 - [Falco](https://github.com/falcosecurity/falco)：CNCF 运行时安全工具，用于检测容器和 Kubernetes 中的可疑行为。
 - [Kyverno](https://github.com/kyverno/kyverno)：Kubernetes 原生策略引擎，支持校验、变更、生成和镜像验证。
+- [Open Policy Agent](https://github.com/open-policy-agent/opa)：通用 policy-as-code 策略引擎，适用于 Kubernetes、CI/CD、API 和基础设施场景。
+- [Gatekeeper](https://github.com/open-policy-agent/gatekeeper)：基于 OPA 的 Kubernetes 准入控制器，用于在集群中执行策略和审计约束。
 - [Syft](https://github.com/anchore/syft)：用于从容器镜像和文件系统生成 SBOM 的 CLI 与库。
 - [Grype](https://github.com/anchore/grype)：面向容器镜像和文件系统的漏洞扫描器，可与 Syft 生成的 SBOM 配合使用。
 - [Kubescape](https://github.com/kubescape/kubescape)：Kubernetes 安全平台，支持风险分析、合规、错误配置扫描，以及 CI/CD 或集群检查。
 - [Gitleaks](https://github.com/gitleaks/gitleaks)：Secret 扫描工具，用于在 Git 仓库、文件和 CI/CD 流程中发现硬编码凭据。
+- [KubeArmor](https://github.com/kubearmor/KubeArmor)：Kubernetes 运行时安全加固系统，基于 LSM 策略实现最小权限工作负载防护。
 - [cosign](https://github.com/sigstore/cosign)：Sigstore 工具，用于签名和验证容器镜像、Blob 与软件制品，并支持透明日志。
 - [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator)：用于在 GitHub Actions 中为构建和发布制品生成 SLSA provenance 的工作流。
 


### PR DESCRIPTION
## Summary
- Add mature policy-as-code and runtime security projects to the Security and Supply Chain section.
- Keep English and Simplified Chinese READMEs semantically aligned.

## Projects or content added
- Open Policy Agent (`open-policy-agent/opa`)
- Gatekeeper (`open-policy-agent/gatekeeper`)
- KubeArmor (`kubearmor/KubeArmor`)

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- Bilingual project parity check passed for the new entries.
- Rebased on latest `origin/main`; verified `origin/main` is an ancestor of HEAD.
- Diff scope reviewed: README.md and README.zh-CN.md only.
- Confirmed `output/` was not staged.

## Risk
- Low: documentation-only additions in an existing category.
- Main curation risk is category noise; these entries are mature and directly relevant to policy/runtime security.

## Auto-merge intent
- Auto-merge is allowed if PR diff remains clean and checks are green or absent.
