### PR TITLE
docs: add DataOps quality and observability tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,15 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Dagster](https://dagster.io/): Data orchestration platform for modeling data assets and managing the data lifecycle.
 - [Apache NiFi](https://nifi.apache.org/): Visual dataflow orchestration for routing, transforming, and coordinating data across systems.
 - [DataHub](https://github.com/datahub-project/datahub): Metadata platform for data discovery, lineage, governance, and observability across modern data and AI stacks.
+- [OpenMetadata](https://github.com/open-metadata/OpenMetadata): Unified metadata platform for data discovery, lineage, governance, and data observability.
 - [Great Expectations](https://github.com/great-expectations/great_expectations): Data quality framework for validating datasets, documenting expectations, and catching pipeline regressions.
+- [Soda Core](https://github.com/sodadata/soda-core): Data contracts and quality checks engine for validating data pipelines in modern data stacks.
+- [Elementary](https://github.com/elementary-data/elementary): dbt-native data observability platform for monitoring pipelines, tests, freshness, and anomalies.
 
 ### Streaming Operations
 
 - [Kafbat UI](https://github.com/kafbat/kafka-ui): Open-source web UI for managing Apache Kafka clusters, topics, consumers, schemas, and Kafka Connect.
+- [Apache SeaTunnel](https://github.com/apache/seatunnel): Distributed data integration platform for high-volume batch and streaming data movement.
 
 ## FinOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,11 +91,15 @@
 - [Dagster](https://dagster.io/)：数据编排平台，支持数据资产建模和全生命周期管理。
 - [Apache NiFi](https://nifi.apache.org/)：可视化数据流编排工具，支持数据路由、转换和系统间协调。
 - [DataHub](https://github.com/datahub-project/datahub)：面向现代数据与 AI 技术栈的元数据平台，支持数据发现、血缘、治理和可观测性。
+- [OpenMetadata](https://github.com/open-metadata/OpenMetadata)：统一元数据平台，支持数据发现、血缘、治理和数据可观测性。
 - [Great Expectations](https://github.com/great-expectations/great_expectations)：数据质量框架，用于验证数据集、记录数据期望并发现流水线回归。
+- [Soda Core](https://github.com/sodadata/soda-core)：面向现代数据栈的数据契约和质量检查引擎，用于验证数据流水线。
+- [Elementary](https://github.com/elementary-data/elementary)：dbt 原生数据可观测平台，用于监控流水线、测试、新鲜度和异常。
 
 ### Streaming Operations 流式数据运维
 
 - [Kafbat UI](https://github.com/kafbat/kafka-ui)：开源 Web UI，用于管理 Apache Kafka 集群、Topic、消费者、Schema 和 Kafka Connect。
+- [Apache SeaTunnel](https://github.com/apache/seatunnel)：分布式数据集成平台，适合大规模批处理和流式数据传输。
 
 ## FinOps
 


### PR DESCRIPTION
## Summary
- Add a small DataOps batch focused on data observability, data quality, and streaming data integration.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- OpenMetadata
- Soda Core
- Elementary
- Apache SeaTunnel

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- Bilingual new-entry parity check passed.
- Diff scope reviewed: README.md and README.zh-CN.md only.
- Branch rebased onto latest origin/main and freshness verified before push.

## Risk
- Low: documentation-only curation change.
- Main risk is category fit/noise; selected projects are mature and directly related to DataOps/data observability.

## Auto-merge intent
- Auto-merge is allowed if PR self-review is clean and checks are green or absent.
