### PR TITLE
docs: add LLMOps and supply-chain evidence tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [promptfoo](https://github.com/promptfoo/promptfoo): Open-source CLI and platform for prompt testing, LLM evaluations, red teaming, and CI/CD regression checks.
 - [Langtrace](https://github.com/Scale3-Labs/langtrace): OpenTelemetry-based observability platform for tracing, evaluating, and monitoring LLM applications.
 - [Future AGI](https://github.com/future-agi/future-agi): Self-hostable platform for evaluating, observing, and improving LLM and AI agent applications.
+- [CozeLoop](https://github.com/coze-dev/coze-loop): AI agent optimization platform covering development, debugging, evaluation, and production monitoring workflows.
+- [Agenta](https://github.com/Agenta-AI/agenta): Open-source LLMOps platform for prompt management, playgrounds, evaluations, and observability.
 - [abtop](https://github.com/graykode/abtop): htop-style terminal monitor for AI coding agent sessions, tokens, context windows, rate limits, and ports.
 - [agenttrace](https://github.com/luoyuctl/agenttrace): Local-first TUI for inspecting AI coding agent cost, tokens, latency, failures, and reports.
 
@@ -150,6 +152,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [KubeArmor](https://github.com/kubearmor/KubeArmor): Kubernetes runtime security enforcement system for least-privilege workload hardening with LSM-based policies.
 - [cosign](https://github.com/sigstore/cosign): Sigstore tool for signing and verifying container images, blobs, and software artifacts with transparency log support.
 - [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator): GitHub Actions workflows for generating SLSA provenance for builds and release artifacts.
+- [Chainloop](https://github.com/chainloop-dev/chainloop): Software supply-chain control plane for collecting SDLC evidence, attestations, SBOMs, VEX, SARIF, and policy checks.
+- [SafeDep vet](https://github.com/safedep/vet): Policy-as-code tool for detecting malicious, vulnerable, or risky open-source package dependencies.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,6 +66,8 @@
 - [promptfoo](https://github.com/promptfoo/promptfoo)：开源 CLI 与平台，用于 Prompt 测试、LLM 评估、红队测试和 CI/CD 回归检查。
 - [Langtrace](https://github.com/Scale3-Labs/langtrace)：基于 OpenTelemetry 的可观测平台，用于追踪、评估和监控 LLM 应用。
 - [Future AGI](https://github.com/future-agi/future-agi)：可自托管平台，用于评估、观测和改进 LLM 与 AI Agent 应用。
+- [CozeLoop](https://github.com/coze-dev/coze-loop)：AI Agent 优化平台，覆盖开发、调试、评估和生产监控流程。
+- [Agenta](https://github.com/Agenta-AI/agenta)：开源 LLMOps 平台，支持 Prompt 管理、调试 playground、评估和可观测性。
 - [abtop](https://github.com/graykode/abtop)：类似 htop 的终端监控工具，用于查看 AI 编码 Agent 会话、Token、上下文窗口、速率限制和端口。
 - [agenttrace](https://github.com/luoyuctl/agenttrace)：本地优先的 TUI，用于检查 AI 编码 Agent 的成本、Token、延迟、失败和报告。
 
@@ -150,6 +152,8 @@
 - [KubeArmor](https://github.com/kubearmor/KubeArmor)：Kubernetes 运行时安全加固系统，基于 LSM 策略实现最小权限工作负载防护。
 - [cosign](https://github.com/sigstore/cosign)：Sigstore 工具，用于签名和验证容器镜像、Blob 与软件制品，并支持透明日志。
 - [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator)：用于在 GitHub Actions 中为构建和发布制品生成 SLSA provenance 的工作流。
+- [Chainloop](https://github.com/chainloop-dev/chainloop)：软件供应链控制平面，用于收集 SDLC 证据、attestation、SBOM、VEX、SARIF 和策略检查结果。
+- [SafeDep vet](https://github.com/safedep/vet)：基于 policy-as-code 的工具，用于发现恶意、有漏洞或高风险的开源依赖包。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
- Add CozeLoop and Agenta to LLM and Agent Observability.
- Add Chainloop and SafeDep vet to Security and Supply Chain.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- CozeLoop: AI agent optimization platform for development, debugging, evaluation, and monitoring.
- Agenta: open-source LLMOps platform for prompt management, evaluations, and observability.
- Chainloop: SDLC evidence and policy control plane for attestations, SBOMs, VEX, and SARIF.
- SafeDep vet: policy-as-code dependency risk scanner for malicious or vulnerable packages.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- Bilingual new-entry parity check passed.
- Diff scope checked: README.md and README.zh-CN.md only.
- Branch rebased on latest origin/main; origin/main is an ancestor of HEAD.
- Remote branch HEAD verified to match local HEAD after push.

## Risk
- Low: documentation-only additions.
- Main risk is category fit/noise; entries were selected for active maintenance, GitHub-first canonical repositories, and direct X-Ops relevance.

## Auto-merge intent
- Auto-merge is allowed if PR review confirms the diff remains docs-only and checks are green or absent.
