### PR TITLE
docs: add LLMOps observability platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Agenta](https://github.com/Agenta-AI/agenta): Open-source LLMOps platform for prompt management, playgrounds, evaluations, and observability.
 - [abtop](https://github.com/graykode/abtop): htop-style terminal monitor for AI coding agent sessions, tokens, context windows, rate limits, and ports.
 - [agenttrace](https://github.com/luoyuctl/agenttrace): Local-first TUI for inspecting AI coding agent cost, tokens, latency, failures, and reports.
+- [TensorZero](https://github.com/tensorzero/tensorzero): Open-source LLMOps platform that combines an LLM gateway, observability, evaluations, optimization, and experimentation.
+- [Evidently](https://github.com/evidentlyai/evidently): Open-source ML and LLM observability framework for evaluation, testing, monitoring, and data quality checks.
+- [RagaAI Catalyst](https://github.com/raga-ai-hub/RagaAI-Catalyst): Agent AI observability and evaluation SDK for tracing, debugging, and monitoring multi-agent LLM systems.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,6 +70,9 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)：开源 LLMOps 平台，支持 Prompt 管理、调试 playground、评估和可观测性。
 - [abtop](https://github.com/graykode/abtop)：类似 htop 的终端监控工具，用于查看 AI 编码 Agent 会话、Token、上下文窗口、速率限制和端口。
 - [agenttrace](https://github.com/luoyuctl/agenttrace)：本地优先的 TUI，用于检查 AI 编码 Agent 的成本、Token、延迟、失败和报告。
+- [TensorZero](https://github.com/tensorzero/tensorzero)：开源 LLMOps 平台，整合 LLM 网关、可观测性、评估、优化和实验能力。
+- [Evidently](https://github.com/evidentlyai/evidently)：开源 ML 与 LLM 可观测性框架，支持评估、测试、监控和数据质量检查。
+- [RagaAI Catalyst](https://github.com/raga-ai-hub/RagaAI-Catalyst)：面向 Agent AI 的可观测与评估 SDK，用于追踪、调试和监控多 Agent LLM 系统。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Add three mature LLMOps/AI observability projects to the LLM and Agent Observability section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- TensorZero: LLM gateway, observability, evaluation, optimization, and experimentation platform.
- Evidently: ML and LLM observability framework for evaluation, testing, monitoring, and data quality checks.
- RagaAI Catalyst: agent AI observability and evaluation SDK for tracing and debugging multi-agent systems.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate project names.
- Bilingual new-entry parity passed for README.md and README.zh-CN.md.
- Diff scope checked: README.md and README.zh-CN.md only.
- Branch rebased onto latest origin/main and origin/main is an ancestor of HEAD.

## Risk
- Documentation-only change; main risk is category fit or description nuance for broad LLMOps projects.
- No generated output, secrets, cache files, or unrelated files staged.

## Auto-merge intent
- Auto-merge is allowed if the PR diff remains docs-only and GitHub checks are green or absent.
