### PR TITLE
docs: add OpenTelemetry observability tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Prometheus](https://github.com/prometheus/prometheus): Monitoring system and time-series database widely used for cloud-native metrics and alerting.
 - [Grafana Loki](https://github.com/grafana/loki): Log aggregation system designed to index labels efficiently and integrate with Grafana.
 - [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector): Vendor-neutral collector for receiving, processing, and exporting telemetry data.
+- [SigNoz](https://github.com/SigNoz/signoz): OpenTelemetry-native observability platform combining metrics, traces, logs, dashboards, and alerts.
+- [Jaeger](https://github.com/jaegertracing/jaeger): CNCF distributed tracing platform for monitoring and troubleshooting microservices.
+- [Vector](https://github.com/vectordotdev/vector): High-performance observability data pipeline for collecting, transforming, and routing logs and metrics.
 - [Grafana Alloy](https://github.com/grafana/alloy): OpenTelemetry Collector distribution with programmable pipelines for collecting, processing, and forwarding observability signals.
 - [Pixie](https://github.com/pixie-io/pixie): Kubernetes-native observability platform that uses eBPF to capture metrics, events, traces, and network telemetry without manual instrumentation.
 - [Parca](https://github.com/parca-dev/parca): Continuous profiling platform for analyzing CPU and memory usage over time to improve performance, reliability, and infrastructure efficiency.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -121,6 +121,9 @@
 - [Prometheus](https://github.com/prometheus/prometheus)：云原生广泛采用的监控系统和时序数据库，适用于指标采集与告警。
 - [Grafana Loki](https://github.com/grafana/loki)：面向标签索引设计的日志聚合系统，可与 Grafana 深度集成。
 - [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)：厂商中立的遥测数据采集器，支持接收、处理和导出指标、日志与链路数据。
+- [SigNoz](https://github.com/SigNoz/signoz)：基于 OpenTelemetry 的开源可观测平台，整合指标、链路、日志、仪表盘和告警。
+- [Jaeger](https://github.com/jaegertracing/jaeger)：CNCF 分布式链路追踪平台，用于监控和排查微服务系统。
+- [Vector](https://github.com/vectordotdev/vector)：高性能可观测数据流水线，用于采集、转换和路由日志与指标。
 - [Grafana Alloy](https://github.com/grafana/alloy)：OpenTelemetry Collector 发行版，提供可编程流水线，用于采集、处理和转发可观测性信号。
 - [Pixie](https://github.com/pixie-io/pixie)：Kubernetes 原生可观测平台，基于 eBPF 自动采集指标、事件、链路和网络遥测，无需手动插桩。
 - [Parca](https://github.com/parca-dev/parca)：持续性能剖析平台，用于分析 CPU 和内存使用随时间的变化，提升性能、可靠性和基础设施效率。


### PR DESCRIPTION
## Summary
- Add three mature OpenTelemetry-aligned observability projects to the Observability section.
- Keep English and Simplified Chinese README entries semantically aligned.

## Projects or content added
- SigNoz: OpenTelemetry-native observability platform for metrics, traces, logs, dashboards, and alerts.
- Jaeger: CNCF distributed tracing platform for microservices troubleshooting.
- Vector: high-performance observability data pipeline for logs and metrics.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- Bilingual entry parity check passed for SigNoz, Jaeger, and Vector.
- Diff scope reviewed: README.md and README.zh-CN.md only.
- Branch rebased onto latest origin/main and origin/main is an ancestor of HEAD.
- output/ was not staged.

## Risk
- Low: documentation-only curated additions.
- Main risk is category growth; entries are limited to mature, directly relevant observability infrastructure.

## Auto-merge intent
- Auto-merge is allowed if PR diff remains clean and checks are green or absent.