### PR TITLE
docs: add supply-chain security scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator): GitHub Actions workflows for generating SLSA provenance for builds and release artifacts.
 - [Chainloop](https://github.com/chainloop-dev/chainloop): Software supply-chain control plane for collecting SDLC evidence, attestations, SBOMs, VEX, SARIF, and policy checks.
 - [SafeDep vet](https://github.com/safedep/vet): Policy-as-code tool for detecting malicious, vulnerable, or risky open-source package dependencies.
+- [OSV-Scanner](https://github.com/google/osv-scanner): Vulnerability scanner that uses OSV.dev data to find known vulnerabilities across source, lockfiles, SBOMs, and container images.
+- [OpenSSF Scorecard](https://github.com/ossf/scorecard): Automated security health checker for open-source projects, covering dependency, CI/CD, branch protection, and vulnerability hygiene signals.
+- [GUAC](https://github.com/guacsec/guac): Software supply-chain graph that aggregates SBOMs, SLSA attestations, vulnerabilities, and dependency metadata for risk analysis.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -164,6 +164,9 @@
 - [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator)：用于在 GitHub Actions 中为构建和发布制品生成 SLSA provenance 的工作流。
 - [Chainloop](https://github.com/chainloop-dev/chainloop)：软件供应链控制平面，用于收集 SDLC 证据、attestation、SBOM、VEX、SARIF 和策略检查结果。
 - [SafeDep vet](https://github.com/safedep/vet)：基于 policy-as-code 的工具，用于发现恶意、有漏洞或高风险的开源依赖包。
+- [OSV-Scanner](https://github.com/google/osv-scanner)：使用 OSV.dev 数据的漏洞扫描器，可在源码、lockfile、SBOM 和容器镜像中发现已知漏洞。
+- [OpenSSF Scorecard](https://github.com/ossf/scorecard)：面向开源项目的自动化安全健康检查工具，覆盖依赖、CI/CD、分支保护和漏洞治理等信号。
+- [GUAC](https://github.com/guacsec/guac)：软件供应链图谱，可聚合 SBOM、SLSA attestation、漏洞和依赖元数据用于风险分析。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
- Add three mature software supply-chain security projects to the Security and Supply Chain section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- OSV-Scanner: vulnerability scanning with OSV.dev data across source, lockfiles, SBOMs, and container images.
- OpenSSF Scorecard: automated security health checks for open-source project practices.
- GUAC: supply-chain metadata graph for SBOMs, SLSA attestations, vulnerabilities, and dependency metadata.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- Bilingual parity check passed for all three new entries.
- Diff scope verified: README.md and README.zh-CN.md only.
- Rebased on latest origin/main and verified origin/main is an ancestor of HEAD.
- output/ was not staged or committed.

## Risk
- Low: documentation-only curated entries.
- Main curation risk is category growth noise; selected projects are mature, active, and directly supply-chain/security scoped.

## Auto-merge intent
- Auto-merge is allowed only if PR diff remains README-only and checks are green or absent. No production experiments; boring green PR preferred.