### PR TITLE
docs: add DevSecOps secret and cloud scanning tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Grype](https://github.com/anchore/grype): Vulnerability scanner for container images and filesystems that works well with Syft-generated SBOMs.
 - [Kubescape](https://github.com/kubescape/kubescape): Kubernetes security platform for risk analysis, compliance, misconfiguration scanning, and CI/CD or cluster checks.
 - [Gitleaks](https://github.com/gitleaks/gitleaks): Secrets scanner for detecting hardcoded credentials in Git repositories, files, and CI/CD workflows.
+- [TruffleHog](https://github.com/trufflesecurity/trufflehog): Secrets scanner that finds, verifies, and analyzes leaked credentials across Git, filesystems, CI logs, and cloud sources.
+- [Prowler](https://github.com/prowler-cloud/prowler): Multi-cloud security and compliance platform for auditing AWS, Azure, GCP, Kubernetes, and SaaS environments.
 - [KubeArmor](https://github.com/kubearmor/KubeArmor): Kubernetes runtime security enforcement system for least-privilege workload hardening with LSM-based policies.
 - [cosign](https://github.com/sigstore/cosign): Sigstore tool for signing and verifying container images, blobs, and software artifacts with transparency log support.
 - [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator): GitHub Actions workflows for generating SLSA provenance for builds and release artifacts.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,6 +159,8 @@
 - [Grype](https://github.com/anchore/grype)：面向容器镜像和文件系统的漏洞扫描器，可与 Syft 生成的 SBOM 配合使用。
 - [Kubescape](https://github.com/kubescape/kubescape)：Kubernetes 安全平台，支持风险分析、合规、错误配置扫描，以及 CI/CD 或集群检查。
 - [Gitleaks](https://github.com/gitleaks/gitleaks)：Secret 扫描工具，用于在 Git 仓库、文件和 CI/CD 流程中发现硬编码凭据。
+- [TruffleHog](https://github.com/trufflesecurity/trufflehog)：Secret 扫描工具，可在 Git、文件系统、CI 日志和云端来源中发现、验证并分析泄露凭据。
+- [Prowler](https://github.com/prowler-cloud/prowler)：多云安全与合规平台，用于审计 AWS、Azure、GCP、Kubernetes 和 SaaS 环境。
 - [KubeArmor](https://github.com/kubearmor/KubeArmor)：Kubernetes 运行时安全加固系统，基于 LSM 策略实现最小权限工作负载防护。
 - [cosign](https://github.com/sigstore/cosign)：Sigstore 工具，用于签名和验证容器镜像、Blob 与软件制品，并支持透明日志。
 - [SLSA GitHub Generator](https://github.com/slsa-framework/slsa-github-generator)：用于在 GitHub Actions 中为构建和发布制品生成 SLSA provenance 的工作流。


### PR DESCRIPTION
## Summary
- Add two mature DevSecOps entries to the Security and Supply Chain section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- TruffleHog: secrets scanner for finding, verifying, and analyzing leaked credentials across Git, filesystems, CI logs, and cloud sources.
- Prowler: multi-cloud security and compliance platform for auditing AWS, Azure, GCP, Kubernetes, and SaaS environments.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- README parity check passed for the new project names.
- Diff scope verified: README.md and README.zh-CN.md only.
- Rebased onto latest origin/main and verified origin/main is an ancestor of HEAD.
- Verified pushed remote branch matches local HEAD.

## Risk
- Low: documentation-only curated additions.
- Main risk is category noise if future security additions are not kept focused on operations, compliance, or supply-chain workflows.

## Auto-merge intent
- Auto-merge is allowed if GitHub checks are green or absent and the PR diff remains limited to the expected README files.
