### PR TITLE
docs: add SBOM compliance tools to supply chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [OSV-Scanner](https://github.com/google/osv-scanner): Vulnerability scanner that uses OSV.dev data to find known vulnerabilities across source, lockfiles, SBOMs, and container images.
 - [OpenSSF Scorecard](https://github.com/ossf/scorecard): Automated security health checker for open-source projects, covering dependency, CI/CD, branch protection, and vulnerability hygiene signals.
 - [GUAC](https://github.com/guacsec/guac): Software supply-chain graph that aggregates SBOMs, SLSA attestations, vulnerabilities, and dependency metadata for risk analysis.
+- [ORT](https://github.com/oss-review-toolkit/ort): Toolkit for automating open-source compliance checks across dependencies, licenses, copyrights, vulnerabilities, and SBOM generation.
+- [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli): Command-line tool for validating, converting, merging, and diffing CycloneDX SBOMs and related formats.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,6 +169,8 @@
 - [OSV-Scanner](https://github.com/google/osv-scanner)：使用 OSV.dev 数据的漏洞扫描器，可在源码、lockfile、SBOM 和容器镜像中发现已知漏洞。
 - [OpenSSF Scorecard](https://github.com/ossf/scorecard)：面向开源项目的自动化安全健康检查工具，覆盖依赖、CI/CD、分支保护和漏洞治理等信号。
 - [GUAC](https://github.com/guacsec/guac)：软件供应链图谱，可聚合 SBOM、SLSA attestation、漏洞和依赖元数据用于风险分析。
+- [ORT](https://github.com/oss-review-toolkit/ort)：用于自动化开源合规检查的工具集，覆盖依赖、License、版权、漏洞和 SBOM 生成。
+- [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli)：用于校验、转换、合并和比对 CycloneDX SBOM 及相关格式的命令行工具。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
- Add SBOM and open-source compliance tooling to the Security and Supply Chain section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- ORT: open-source compliance automation across dependencies, licenses, copyrights, vulnerabilities, and SBOM generation.
- CycloneDX CLI: command-line validation, conversion, merging, and diffing for CycloneDX SBOMs and related formats.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- Bilingual catalog project parity check passed.
- Diff scope limited to README.md and README.zh-CN.md.
- Branch rebased on latest origin/main and origin/main is an ancestor of HEAD.
- output/ was not staged.

## Risk
- Low: documentation-only curation change.
- Main risk is category density in Security and Supply Chain; entries were limited to mature, actively maintained SBOM/compliance tools.

## Auto-merge intent
- Auto-merge is allowed if PR diff remains docs-only and checks are green or absent.