### PR TITLE
docs: add KnoxOps to Agentic Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [LlamaIndex](https://github.com/run-llama/llama_index): Data framework for LLM applications, supporting structured data retrieval and augmentation.
 - [Haystack](https://github.com/deepset-ai/haystack): Extensible framework for question answering and custom AI workflow development.
 - [BentoML](https://github.com/bentoml/BentoML): Open-source model serving platform for deploying models across frameworks and orchestrating AI applications.
+- [KnoxOps](https://knoxops.app/?invite_token=GITHUB26): AI-native ops agent for SREs — gives agents production execution power with safety guardrails, human review, and a built-in knowledge graph of your infrastructure.
 
 ## DataOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,6 +90,7 @@
 - [LlamaIndex](https://github.com/run-llama/llama_index)：LLM 数据框架，支持结构化数据检索和增强。
 - [Haystack](https://github.com/deepset-ai/haystack)：可扩展的问答系统框架，支持自定义 AI 工作流构建。
 - [BentoML](https://github.com/bentoml/BentoML)：开源模型服务平台，支持多框架模型部署和 AI 应用编排。
+- [KnoxOps](https://knoxops.app/?invite_token=GITHUB26)：AI 原生的 SRE 运维智能体——在安全围栏内赋予 Agent 生产环境执行能力，强制人工审核，内置基础设施知识图谱。
 
 ## DataOps
 


### PR DESCRIPTION
## Summary
Add KnoxOps to the Agentic Workflow section in both README.md and README.zh-CN.md.

## Projects or content added
- KnoxOps — AI-native ops agent for SREs that gives agents production execution power within safety guardrails, with human review and a built-in knowledge graph of production infrastructure.

## Validation
- Both README.md and README.zh-CN.md updated
- English description ends with period
- Chinese mirror description uses matching colon-separator format
- No duplicate links