### PR TITLE
docs: add MLflow to LLM observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [RagaAI Catalyst](https://github.com/raga-ai-hub/RagaAI-Catalyst): Agent AI observability and evaluation SDK for tracing, debugging, and monitoring multi-agent LLM systems.
 - [Pydantic Logfire](https://github.com/pydantic/logfire): AI observability platform for tracing and monitoring production LLM and agent systems.
 - [Laminar](https://github.com/lmnr-ai/lmnr): Open-source observability platform purpose-built for AI agents and LLM applications.
+- [MLflow](https://github.com/mlflow/mlflow): Open-source AI engineering platform for debugging, evaluating, monitoring, and optimizing agents, LLMs, and ML models.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,6 +75,7 @@
 - [RagaAI Catalyst](https://github.com/raga-ai-hub/RagaAI-Catalyst)：面向 Agent AI 的可观测与评估 SDK，用于追踪、调试和监控多 Agent LLM 系统。
 - [Pydantic Logfire](https://github.com/pydantic/logfire)：面向生产级 LLM 与 Agent 系统的 AI 可观测平台，用于链路追踪和监控。
 - [Laminar](https://github.com/lmnr-ai/lmnr)：专为 AI Agent 和 LLM 应用构建的开源可观测平台。
+- [MLflow](https://github.com/mlflow/mlflow)：开源 AI 工程平台，用于调试、评估、监控和优化 Agent、LLM 与机器学习模型。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Adds MLflow to the LLM and Agent Observability section in both English and Simplified Chinese READMEs.
- Uses the canonical GitHub repository link and concise production-AI observability wording.

## Projects or content added
- MLflow: open-source AI engineering platform for debugging, evaluating, monitoring, and optimizing agents, LLMs, and ML models.

## Validation
- Markdown structural checks passed.
- Duplicate URL and duplicate project-name checks passed.
- Bilingual MLflow parity check passed.
- Branch rebased onto latest origin/main and origin/main is an ancestor of HEAD.
- Diff scope limited to README.md and README.zh-CN.md.

## Risk
- Low: documentation-only addition, but category fit should still be reviewed because MLflow spans ML/LLMOps beyond pure observability.

## Auto-merge intent
- Auto-merge only if PR diff remains README-only and checks are green or absent.