### PR TITLE
docs: add scalable observability backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 ## Observability
 
 - [Prometheus](https://github.com/prometheus/prometheus): Monitoring system and time-series database widely used for cloud-native metrics and alerting.
+- [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics): Fast, cost-efficient time-series database and monitoring stack for Prometheus-compatible metrics at scale.
+- [Grafana Mimir](https://github.com/grafana/mimir): Horizontally scalable, multi-tenant long-term storage backend for Prometheus metrics.
+- [Grafana Tempo](https://github.com/grafana/tempo): Distributed tracing backend for high-volume trace storage with minimal indexing overhead.
+- [Perses](https://github.com/perses/perses): CNCF observability visualization project for building dashboards across Prometheus, Tempo, Loki, and related data sources.
 - [Grafana Loki](https://github.com/grafana/loki): Log aggregation system designed to index labels efficiently and integrate with Grafana.
 - [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector): Vendor-neutral collector for receiving, processing, and exporting telemetry data.
 - [SigNoz](https://github.com/SigNoz/signoz): OpenTelemetry-native observability platform combining metrics, traces, logs, dashboards, and alerts.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -122,6 +122,10 @@
 ## Observability 可观测性
 
 - [Prometheus](https://github.com/prometheus/prometheus)：云原生广泛采用的监控系统和时序数据库，适用于指标采集与告警。
+- [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)：高性能、成本友好的时序数据库和监控栈，适合大规模 Prometheus 兼容指标场景。
+- [Grafana Mimir](https://github.com/grafana/mimir)：可水平扩展、多租户的 Prometheus 指标长期存储后端。
+- [Grafana Tempo](https://github.com/grafana/tempo)：面向大规模链路数据的分布式追踪后端，以较低索引开销存储高容量 trace。
+- [Perses](https://github.com/perses/perses)：CNCF 可观测性可视化项目，用于基于 Prometheus、Tempo、Loki 等数据源构建仪表盘。
 - [Grafana Loki](https://github.com/grafana/loki)：面向标签索引设计的日志聚合系统，可与 Grafana 深度集成。
 - [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)：厂商中立的遥测数据采集器，支持接收、处理和导出指标、日志与链路数据。
 - [SigNoz](https://github.com/SigNoz/signoz)：基于 OpenTelemetry 的开源可观测平台，整合指标、链路、日志、仪表盘和告警。


### PR DESCRIPTION
## Summary
- Add mature observability backends and dashboarding projects to the Observability section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- VictoriaMetrics: Prometheus-compatible time-series database and monitoring stack.
- Grafana Mimir: scalable long-term storage for Prometheus metrics.
- Grafana Tempo: distributed tracing backend for high-volume trace storage.
- Perses: CNCF observability dashboard visualization project.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate names.
- Bilingual new-entry parity check passed.
- Rebased on latest origin/main before push.
- Diff scope limited to README.md and README.zh-CN.md.

## Risk
- Low: documentation-only curation change.
- Main risk is category fit/noise; entries are mature, active, and directly relevant to production observability.

## Auto-merge intent
- Auto-merge is allowed only if PR self-review passes and checks are green or absent.