### PR TITLE
docs: add Apache HertzBeat to AIOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 ## AIOps
 
 - [Netdata](https://github.com/netdata/netdata): Distributed real-time monitoring for infrastructure metrics, visualization, and alerting.
+- [Apache HertzBeat](https://github.com/apache/hertzbeat): Apache real-time observability and monitoring system with agentless collection, alerting, status pages, and AI-assisted operations.
 - [PostHog](https://github.com/PostHog/posthog): Open-source product analytics platform for user behavior tracking and product metrics.
 
 ## Agentic Workflow

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,6 +80,7 @@
 ## AIOps 智能运维
 
 - [Netdata](https://github.com/netdata/netdata)：分布式实时监控系统，提供基础设施指标收集、可视化和告警功能。
+- [Apache HertzBeat](https://github.com/apache/hertzbeat)：Apache 实时可观测与监控系统，支持无 Agent 采集、告警、状态页和 AI 辅助运维。
 - [PostHog](https://github.com/PostHog/posthog)：开源产品分析平台，支持用户行为追踪和产品指标分析。
 
 ## Agentic Workflow 智能体工作流


### PR DESCRIPTION
## Summary
- Add Apache HertzBeat to the AIOps section in both English and Simplified Chinese READMEs.
- Keep the update docs-only and scoped to real-time observability/monitoring coverage.

## Projects or content added
- Apache HertzBeat: Apache real-time observability and monitoring system with agentless collection, alerting, status pages, and AI-assisted operations.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- Bilingual parity check confirmed the new project appears in both README variants.
- Rebased onto latest origin/main and verified origin/main is an ancestor of the branch HEAD.
- Diff scope reviewed as README.md and README.zh-CN.md only.

## Risk
- Low: documentation-only addition.
- Main curation risk is category fit; HertzBeat is placed under AIOps because its project description and topics emphasize real-time observability, monitoring, alerting, and AI-assisted operations.

## Auto-merge intent
- Auto-merge is allowed only if PR self-review passes and checks are green or absent.