### PR TITLE
docs: add LLM evaluation guardrail tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Pydantic Logfire](https://github.com/pydantic/logfire): AI observability platform for tracing and monitoring production LLM and agent systems.
 - [Laminar](https://github.com/lmnr-ai/lmnr): Open-source observability platform purpose-built for AI agents and LLM applications.
 - [MLflow](https://github.com/mlflow/mlflow): Open-source AI engineering platform for debugging, evaluating, monitoring, and optimizing agents, LLMs, and ML models.
+- [Giskard](https://github.com/Giskard-AI/giskard-oss): Open-source evaluation and testing framework for LLM applications and AI agents.
+- [ZenML](https://github.com/zenml-io/zenml): AI platform for production ML, LLM, and agent pipelines with orchestration, tracking, and deployment workflows.
+- [Guardrails](https://github.com/guardrails-ai/guardrails): Framework for validating LLM outputs and enforcing safety, quality, and structured response checks.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,6 +76,9 @@
 - [Pydantic Logfire](https://github.com/pydantic/logfire)：面向生产级 LLM 与 Agent 系统的 AI 可观测平台，用于链路追踪和监控。
 - [Laminar](https://github.com/lmnr-ai/lmnr)：专为 AI Agent 和 LLM 应用构建的开源可观测平台。
 - [MLflow](https://github.com/mlflow/mlflow)：开源 AI 工程平台，用于调试、评估、监控和优化 Agent、LLM 与机器学习模型。
+- [Giskard](https://github.com/Giskard-AI/giskard-oss)：面向 LLM 应用和 AI Agent 的开源评估与测试框架。
+- [ZenML](https://github.com/zenml-io/zenml)：面向生产级 ML、LLM 和 Agent 流水线的 AI 平台，支持编排、追踪和部署工作流。
+- [Guardrails](https://github.com/guardrails-ai/guardrails)：用于校验 LLM 输出并执行安全、质量和结构化响应检查的框架。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Adds three production-oriented LLM evaluation, pipeline, and guardrail tools to the LLM and Agent Observability section.
- Keeps README.md and README.zh-CN.md aligned with concise bilingual descriptions.

## Projects or content added
- Giskard: LLM application and AI agent evaluation/testing.
- ZenML: production ML, LLM, and agent pipeline platform.
- Guardrails: LLM output validation and quality/safety guardrails.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- Diff scope is limited to README.md and README.zh-CN.md.
- Branch rebased on latest origin/main and origin/main is an ancestor of HEAD.

## Risk
- Low: documentation-only curation update.
- Main content risk is category fit; entries are placed under LLM and Agent Observability because they support production evaluation, monitoring, and guardrail workflows.

## Auto-merge intent
- Auto-merge is allowed only if PR diff remains docs-only and GitHub checks are green or absent.
