### PR TITLE
docs: add AIOps and cloud governance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Netdata](https://github.com/netdata/netdata): Distributed real-time monitoring for infrastructure metrics, visualization, and alerting.
 - [Apache HertzBeat](https://github.com/apache/hertzbeat): Apache real-time observability and monitoring system with agentless collection, alerting, status pages, and AI-assisted operations.
 - [PostHog](https://github.com/PostHog/posthog): Open-source product analytics platform for user behavior tracking and product metrics.
+- [SREWorks](https://github.com/alibaba/SREWorks): Cloud-native DataOps and AIOps platform for operating Kubernetes-based applications and infrastructure.
 
 ## Agentic Workflow
 
@@ -121,6 +122,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [kubecost](https://kubecost.com/): Kubernetes cost management and monitoring platform.
 - [OpenCost](https://opencost.io/): Open-source tool for tracking and allocating cloud costs in Kubernetes environments.
 - [OptScale](https://github.com/hystax/optscale): Open-source FinOps and cloud cost optimization platform for AWS, Azure, GCP, Alibaba Cloud, and Kubernetes.
+- [Cloud Custodian](https://github.com/cloud-custodian/cloud-custodian): Policy-as-code rules engine for cloud governance, cost optimization, and automated resource actions.
 - [KubeStellar Console](https://github.com/kubestellar/console): Multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and CNCF project integrations across edge and cloud clusters.
 
 ## Observability

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,6 +85,7 @@
 - [Netdata](https://github.com/netdata/netdata)：分布式实时监控系统，提供基础设施指标收集、可视化和告警功能。
 - [Apache HertzBeat](https://github.com/apache/hertzbeat)：Apache 实时可观测与监控系统，支持无 Agent 采集、告警、状态页和 AI 辅助运维。
 - [PostHog](https://github.com/PostHog/posthog)：开源产品分析平台，支持用户行为追踪和产品指标分析。
+- [SREWorks](https://github.com/alibaba/SREWorks)：云原生 DataOps 与 AIOps 平台，用于运维 Kubernetes 应用和基础设施。
 
 ## Agentic Workflow 智能体工作流
 
@@ -121,6 +122,7 @@
 - [kubecost](https://kubecost.com/)：Kubernetes 成本管理与监控工具。
 - [OpenCost](https://opencost.io/)：开源工具，用于跟踪和分摊 Kubernetes 环境中的云成本。
 - [OptScale](https://github.com/hystax/optscale)：开源 FinOps 与云成本优化平台，支持 AWS、Azure、GCP、阿里云和 Kubernetes。
+- [Cloud Custodian](https://github.com/cloud-custodian/cloud-custodian)：基于 policy-as-code 的云治理和成本优化规则引擎，支持自动化资源处置。
 - [KubeStellar Console](https://github.com/kubestellar/console)：多集群 Kubernetes 控制台，提供 AI 辅助运维、实时可观测性和边缘/云集群管理能力。
 
 ## Observability 可观测性


### PR DESCRIPTION
## Summary
- Add SREWorks to the AIOps section.
- Add Cloud Custodian to the FinOps section for cloud governance and cost optimization.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- SREWorks: cloud-native DataOps and AIOps platform for Kubernetes-based operations.
- Cloud Custodian: policy-as-code rules engine for cloud governance, cost optimization, and automated resource actions.

## Validation
- `python3` markdown structural checks: internal links, duplicate URLs, duplicate entry names.
- Bilingual additions check for both new project names in `README.md` and `README.zh-CN.md`.
- Diff scope limited to `README.md` and `README.zh-CN.md`.
- Rebased on latest `origin/main`; verified `origin/main` is an ancestor of HEAD.

## Risk
- Low: documentation-only curation update.
- Review should confirm category fit and wording before merge.

## Auto-merge intent
- Auto-merge only if PR diff remains README-only and checks are green or absent.
