### PR TITLE
docs: add Dependency-Track to supply chain security

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [GUAC](https://github.com/guacsec/guac): Software supply-chain graph that aggregates SBOMs, SLSA attestations, vulnerabilities, and dependency metadata for risk analysis.
 - [ORT](https://github.com/oss-review-toolkit/ort): Toolkit for automating open-source compliance checks across dependencies, licenses, copyrights, vulnerabilities, and SBOM generation.
 - [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli): Command-line tool for validating, converting, merging, and diffing CycloneDX SBOMs and related formats.
+- [Dependency-Track](https://github.com/DependencyTrack/dependency-track): Component analysis platform for tracking SBOMs, vulnerabilities, licenses, and software supply-chain risk.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -187,6 +187,7 @@
 - [GUAC](https://github.com/guacsec/guac)：软件供应链图谱，可聚合 SBOM、SLSA attestation、漏洞和依赖元数据用于风险分析。
 - [ORT](https://github.com/oss-review-toolkit/ort)：用于自动化开源合规检查的工具集，覆盖依赖、License、版权、漏洞和 SBOM 生成。
 - [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli)：用于校验、转换、合并和比对 CycloneDX SBOM 及相关格式的命令行工具。
+- [Dependency-Track](https://github.com/DependencyTrack/dependency-track)：组件分析平台，用于跟踪 SBOM、漏洞、License 和软件供应链风险。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
- Add Dependency-Track to the Security and Supply Chain section in both English and Simplified Chinese READMEs.
- Keep the update docs-only and scoped to software supply-chain risk and SBOM component analysis.

## Projects or content added
- Dependency-Track: Component analysis platform for tracking SBOMs, vulnerabilities, licenses, and software supply-chain risk.

## Validation
- `python3` Markdown structural checks: internal links, duplicate URLs, duplicate entry names.
- Bilingual parity check confirmed the new GitHub URL exists in both README files.
- `git diff --check`
- Diff scope limited to `README.md` and `README.zh-CN.md`.
- Branch rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.

## Risk
- Low: documentation-only addition.
- Main risk is list growth noise; candidate is mature, active, and directly relevant to SBOM/software supply-chain security.

## Auto-merge intent
- Auto-merge only if PR review confirms the diff is expected and checks are green or absent.
