### PR TITLE
docs: add data lineage tools to DataOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Great Expectations](https://github.com/great-expectations/great_expectations): Data quality framework for validating datasets, documenting expectations, and catching pipeline regressions.
 - [Soda Core](https://github.com/sodadata/soda-core): Data contracts and quality checks engine for validating data pipelines in modern data stacks.
 - [Elementary](https://github.com/elementary-data/elementary): dbt-native data observability platform for monitoring pipelines, tests, freshness, and anomalies.
+- [OpenLineage](https://github.com/OpenLineage/OpenLineage): Open standard and tooling for collecting lineage metadata across data pipelines and platforms.
+- [Marquez](https://github.com/MarquezProject/marquez): Metadata service for collecting, aggregating, and visualizing data lineage across jobs and datasets.
 - [Temporal](https://github.com/temporalio/temporal): Durable execution platform for building reliable workflows, background jobs, and long-running business processes.
 - [Kestra](https://github.com/kestra-io/kestra): Event-driven orchestration and scheduling platform for declarative data, infrastructure, and operational workflows.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,6 +108,8 @@
 - [Great Expectations](https://github.com/great-expectations/great_expectations)：数据质量框架，用于验证数据集、记录数据期望并发现流水线回归。
 - [Soda Core](https://github.com/sodadata/soda-core)：面向现代数据栈的数据契约和质量检查引擎，用于验证数据流水线。
 - [Elementary](https://github.com/elementary-data/elementary)：dbt 原生数据可观测平台，用于监控流水线、测试、新鲜度和异常。
+- [OpenLineage](https://github.com/OpenLineage/OpenLineage)：用于在数据流水线和平台之间采集血缘元数据的开放标准与工具集。
+- [Marquez](https://github.com/MarquezProject/marquez)：元数据服务，用于采集、聚合并可视化作业和数据集之间的数据血缘。
 - [Temporal](https://github.com/temporalio/temporal)：持久化执行平台，用于构建可靠的工作流、后台任务和长周期业务流程。
 - [Kestra](https://github.com/kestra-io/kestra)：事件驱动的编排与调度平台，支持声明式数据、基础设施和运维工作流。
 


### PR DESCRIPTION
## Summary
- Add OpenLineage and Marquez to the DataOps section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- OpenLineage: open standard and tooling for collecting lineage metadata across data pipelines and platforms.
- Marquez: metadata service for collecting, aggregating, and visualizing data lineage across jobs and datasets.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- Bilingual project parity check passed for the two added repositories.
- Diff scope checked: README.md and README.zh-CN.md only.
- Branch rebased onto latest origin/main and origin/main is an ancestor of HEAD.

## Risk
- Low: documentation-only addition to an existing DataOps section.
- Main risk is curation quality/noise; both projects are active, non-archived Apache-2.0 repositories with established lineage relevance.

## Auto-merge intent
- Auto-merge only if PR diff remains docs-only and checks are green or absent.
