### PR TITLE
docs: add Kubernetes operations lifecycle tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Botkube](https://github.com/kubeshop/botkube): Kubernetes ChatOps assistant for monitoring clusters, surfacing events, and helping teams debug deployments.
 - [mirrord](https://github.com/metalbear-co/mirrord): Kubernetes development tool that lets local processes run with cluster networking, environment, and traffic context.
 - [OpenKruise](https://github.com/openkruise/kruise): CNCF Kubernetes workload automation suite for advanced application deployment, scaling, and lifecycle management.
+- [kOps](https://github.com/kubernetes/kops): Production-grade Kubernetes cluster lifecycle tool for installation, upgrades, and operations across cloud environments.
+- [KubeOne](https://github.com/kubermatic/kubeone): Kubernetes cluster lifecycle management tool for automating operations across cloud, on-prem, edge, and IoT environments.
 
 ## Security and Supply Chain
 
@@ -218,6 +220,7 @@ A curated technology stack and toolchain for platform engineering.
 - [argo-workflows](https://github.com/argoproj/argo-workflows): Kubernetes-native workflow engine.
 - [Tekton](https://tekton.dev/): Kubernetes-native CI/CD framework with flexible task orchestration.
 - [Flux](https://fluxcd.io/): Popular Kubernetes GitOps toolkit.
+- [PipeCD](https://github.com/pipe-cd/pipecd): CNCF continuous delivery platform for applications, infrastructure, and platform operations across multiple deployment targets.
 
 ### Code Service
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,6 +166,8 @@
 - [Botkube](https://github.com/kubeshop/botkube)：Kubernetes ChatOps 助手，用于监控集群、暴露事件并帮助团队调试部署。
 - [mirrord](https://github.com/metalbear-co/mirrord)：Kubernetes 开发工具，让本地进程使用集群网络、环境变量和流量上下文运行。
 - [OpenKruise](https://github.com/openkruise/kruise)：CNCF Kubernetes 工作负载自动化套件，支持高级应用部署、弹性伸缩和生命周期管理。
+- [kOps](https://github.com/kubernetes/kops)：生产级 Kubernetes 集群生命周期工具，支持跨云环境的安装、升级和运维。
+- [KubeOne](https://github.com/kubermatic/kubeone)：Kubernetes 集群生命周期管理工具，用于自动化云端、本地、边缘和 IoT 环境的集群运维。
 
 ## Security and Supply Chain 安全与供应链
 
@@ -218,6 +220,7 @@
 - [argo-workflows](https://github.com/argoproj/argo-workflows)：Kubernetes 原生工作流引擎。
 - [Tekton](https://tekton.dev/)：Kubernetes 原生 CI/CD 框架，提供灵活的任务编排能力。
 - [Flux](https://fluxcd.io/)：流行的 Kubernetes GitOps 工具包。
+- [PipeCD](https://github.com/pipe-cd/pipecd)：CNCF 持续交付平台，支持跨多种部署目标管理应用、基础设施和平台运维。
 
 ### Code Service 代码服务
 


### PR DESCRIPTION
## Summary
- Add three mature Kubernetes operations and delivery lifecycle tools to the awesome-x-ops catalog.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- kOps: production-grade Kubernetes cluster installation, upgrades, and operations.
- KubeOne: Kubernetes cluster lifecycle automation across cloud, on-prem, edge, and IoT environments.
- PipeCD: CNCF continuous delivery for applications, infrastructure, and platform operations.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- Bilingual addition parity passed for all three new repository URLs.
- Rebased on latest origin/main and verified origin/main is an ancestor of HEAD.
- Diff scope verified as README.md and README.zh-CN.md only.
- output/ was not staged or committed.

## Risk
- Low docs-only risk; main curation risk is category fit, with PipeCD placed under CI/CD and kOps/KubeOne under Kubernetes Operations.

## Auto-merge intent
- Auto-merge only if PR diff self-review remains clean and checks are green or absent.