### PR TITLE
docs: add feature management tools to platform engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ A curated technology stack and toolchain for platform engineering.
 - [Argo Events](https://argoproj.github.io/argo-events/): Event-driven workflow automation framework for Kubernetes.
 - [Apache EventMesh](https://eventmesh.apache.org/): Distributed event middleware supporting multiple messaging protocols and event stream management.
 
+### Feature Management and Experimentation
+
+- [GrowthBook](https://github.com/growthbook/growthbook): Open-source feature flagging, experimentation, and product analytics platform for safer progressive delivery.
+- [Flagsmith](https://github.com/Flagsmith/flagsmith): Open-source feature flag and remote configuration service for self-hosted or managed release control.
+
 ### Infrastructure as Code (IaC)
 
 Infrastructure as Code manages and provisions infrastructure through code instead of manual processes.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -238,6 +238,11 @@
 - [Argo Events](https://argoproj.github.io/argo-events/)：Kubernetes 事件驱动工作流自动化框架。
 - [Apache EventMesh](https://eventmesh.apache.org/)：分布式事件中间件，支持多种消息协议和事件流管理。
 
+### Feature Management and Experimentation 特性管理与实验
+
+- [GrowthBook](https://github.com/growthbook/growthbook)：开源特性开关、实验和产品分析平台，用于更安全的渐进式交付。
+- [Flagsmith](https://github.com/Flagsmith/flagsmith)：开源特性开关与远程配置服务，支持自托管或托管模式下的发布控制。
+
 ### Infrastructure as Code (IaC)
 
 Infrastructure as Code，基础设施即代码，是通过代码而非手动流程来管理和配置基础设施的方法。


### PR DESCRIPTION
## Summary
- Add a focused Platform Engineering subsection for feature management and experimentation.
- Add GrowthBook and Flagsmith to both English and Simplified Chinese README files.

## Projects or content added
- GrowthBook: open-source feature flagging, experimentation, and product analytics platform.
- Flagsmith: open-source feature flag and remote configuration service.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate project names.
- Bilingual project parity check passed for GrowthBook and Flagsmith.
- Diff scope verified: README.md and README.zh-CN.md only.
- Branch rebased on latest origin/main and origin/main is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD after push.

## Risk
- Low: documentation-only update.
- Category scope risk is limited by keeping the new subsection focused on release-control and experimentation tooling.

## Auto-merge intent
- Auto-merge if PR diff remains docs-only and checks are green or absent.