### PR TITLE
docs: add agent gateway and tracing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Giskard](https://github.com/Giskard-AI/giskard-oss): Open-source evaluation and testing framework for LLM applications and AI agents.
 - [ZenML](https://github.com/zenml-io/zenml): AI platform for production ML, LLM, and agent pipelines with orchestration, tracking, and deployment workflows.
 - [Guardrails](https://github.com/guardrails-ai/guardrails): Framework for validating LLM outputs and enforcing safety, quality, and structured response checks.
+- [Plano](https://github.com/katanemo/plano): AI-native proxy and data plane for agentic applications with routing, safety, orchestration, and observability.
+- [AgentSight](https://github.com/eunomia-bpf/agentsight): eBPF-based system-level tracing for observing AI agent execution without application instrumentation.
 
 ## AIOps
 
@@ -99,6 +101,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [LlamaIndex](https://github.com/run-llama/llama_index): Data framework for LLM applications, supporting structured data retrieval and augmentation.
 - [Haystack](https://github.com/deepset-ai/haystack): Extensible framework for question answering and custom AI workflow development.
 - [BentoML](https://github.com/bentoml/BentoML): Open-source model serving platform for deploying models across frameworks and orchestrating AI applications.
+- [trpc-agent-go](https://github.com/trpc-group/trpc-agent-go): Go framework for production agent systems with graph workflows, tools, memory, evaluation, and observability.
 
 ## DataOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,6 +80,8 @@
 - [Giskard](https://github.com/Giskard-AI/giskard-oss)：面向 LLM 应用和 AI Agent 的开源评估与测试框架。
 - [ZenML](https://github.com/zenml-io/zenml)：面向生产级 ML、LLM 和 Agent 流水线的 AI 平台，支持编排、追踪和部署工作流。
 - [Guardrails](https://github.com/guardrails-ai/guardrails)：用于校验 LLM 输出并执行安全、质量和结构化响应检查的框架。
+- [Plano](https://github.com/katanemo/plano)：面向 Agent 应用的 AI 原生代理与数据平面，支持路由、安全、编排和可观测性。
+- [AgentSight](https://github.com/eunomia-bpf/agentsight)：基于 eBPF 的系统级追踪工具，无需应用插桩即可观测 AI Agent 执行过程。
 
 ## AIOps 智能运维
 
@@ -99,6 +101,7 @@
 - [LlamaIndex](https://github.com/run-llama/llama_index)：LLM 数据框架，支持结构化数据检索和增强。
 - [Haystack](https://github.com/deepset-ai/haystack)：可扩展的问答系统框架，支持自定义 AI 工作流构建。
 - [BentoML](https://github.com/bentoml/BentoML)：开源模型服务平台，支持多框架模型部署和 AI 应用编排。
+- [trpc-agent-go](https://github.com/trpc-group/trpc-agent-go)：用于构建生产级 Agent 系统的 Go 框架，支持图工作流、工具、记忆、评估和可观测性。
 
 ## DataOps
 


### PR DESCRIPTION
## Summary
- Add Plano as an AI-native proxy and data plane for agentic applications.
- Add AgentSight for eBPF-based system-level AI agent tracing.
- Add trpc-agent-go as a production-oriented Go framework for agent systems with evaluation and observability.
- Keep English and Simplified Chinese README entries aligned.

## Projects or Content Added
- Plano: AI gateway/data plane with routing, safety, orchestration, and observability.
- AgentSight: zero-instrumentation eBPF tracing for AI agent execution.
- trpc-agent-go: production agent framework with graph workflows, tools, memory, evaluation, and observability.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, duplicate entry names, and bilingual presence of new entries.
- Changed files are limited to README.md and README.zh-CN.md.
- Branch was rebased onto latest origin/main before push.

## Risk
- Low docs-only risk; project positioning should still be reviewed for category fit.
- Plano and AgentSight are newer operational tools, so future curation should watch maturity and maintenance signals.

## Auto-merge intent
- Auto-merge allowed only after PR diff review and checks are green or absent.
