### PR TITLE
docs: add agent monitoring and AI gateway tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Guardrails](https://github.com/guardrails-ai/guardrails): Framework for validating LLM outputs and enforcing safety, quality, and structured response checks.
 - [Plano](https://github.com/katanemo/plano): AI-native proxy and data plane for agentic applications with routing, safety, orchestration, and observability.
 - [AgentSight](https://github.com/eunomia-bpf/agentsight): eBPF-based system-level tracing for observing AI agent execution without application instrumentation.
+- [AgentOps](https://github.com/AgentOps-AI/agentops): Python SDK for monitoring AI agents, tracking LLM costs, benchmarking runs, and integrating with common agent frameworks.
+- [Portkey AI Gateway](https://github.com/Portkey-AI/gateway): AI gateway for routing LLM traffic, applying guardrails, and centralizing model access for production applications.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,6 +82,8 @@
 - [Guardrails](https://github.com/guardrails-ai/guardrails)：用于校验 LLM 输出并执行安全、质量和结构化响应检查的框架。
 - [Plano](https://github.com/katanemo/plano)：面向 Agent 应用的 AI 原生代理与数据平面，支持路由、安全、编排和可观测性。
 - [AgentSight](https://github.com/eunomia-bpf/agentsight)：基于 eBPF 的系统级追踪工具，无需应用插桩即可观测 AI Agent 执行过程。
+- [AgentOps](https://github.com/AgentOps-AI/agentops)：用于监控 AI Agent、追踪 LLM 成本、基准测试运行并集成常见 Agent 框架的 Python SDK。
+- [Portkey AI Gateway](https://github.com/Portkey-AI/gateway)：AI 网关，用于路由 LLM 流量、应用护栏，并集中管理生产应用的模型访问。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Add two production-oriented AI operations projects to the LLM and Agent Observability section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- AgentOps: AI agent monitoring, LLM cost tracking, benchmarking, and framework integrations.
- Portkey AI Gateway: LLM traffic routing, guardrails, and centralized model access for production applications.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- Bilingual new project parity check passed.
- Diff scope reviewed: README.md and README.zh-CN.md only.
- Branch rebased on latest origin/main and origin/main is an ancestor of HEAD.

## Risk
- Low documentation-only risk.
- Main curation risk is category fit: both entries are intentionally placed under LLM and Agent Observability because they support production AI operations, monitoring, routing, and guardrails.

## Auto-merge intent
- Auto-merge may proceed only if PR self-review remains clean and required checks are green or absent.