### PR TITLE
docs: add LLM DevOps observability platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [AgentSight](https://github.com/eunomia-bpf/agentsight): eBPF-based system-level tracing for observing AI agent execution without application instrumentation.
 - [AgentOps](https://github.com/AgentOps-AI/agentops): Python SDK for monitoring AI agents, tracking LLM costs, benchmarking runs, and integrating with common agent frameworks.
 - [Portkey AI Gateway](https://github.com/Portkey-AI/gateway): AI gateway for routing LLM traffic, applying guardrails, and centralizing model access for production applications.
+- [BISHENG](https://github.com/dataelement/bisheng): Open LLM DevOps platform for enterprise AI applications, with GenAI workflows, RAG, agents, model management, evaluation, datasets, and observability.
+- [OpenObserve](https://github.com/openobserve/openobserve): Open-source observability platform for logs, metrics, traces, frontend monitoring, pipelines, and LLM observability.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,6 +84,8 @@
 - [AgentSight](https://github.com/eunomia-bpf/agentsight)：基于 eBPF 的系统级追踪工具，无需应用插桩即可观测 AI Agent 执行过程。
 - [AgentOps](https://github.com/AgentOps-AI/agentops)：用于监控 AI Agent、追踪 LLM 成本、基准测试运行并集成常见 Agent 框架的 Python SDK。
 - [Portkey AI Gateway](https://github.com/Portkey-AI/gateway)：AI 网关，用于路由 LLM 流量、应用护栏，并集中管理生产应用的模型访问。
+- [BISHENG](https://github.com/dataelement/bisheng)：面向企业 AI 应用的开源 LLM DevOps 平台，覆盖 GenAI 工作流、RAG、Agent、模型管理、评估、数据集和可观测性。
+- [OpenObserve](https://github.com/openobserve/openobserve)：开源可观测平台，覆盖日志、指标、链路、前端监控、流水线和 LLM 可观测性。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Add BISHENG and OpenObserve to the LLM and Agent Observability map.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- BISHENG: open LLM DevOps platform for enterprise AI applications, covering GenAI workflows, RAG, agents, model management, evaluation, datasets, and observability.
- OpenObserve: open-source observability platform for logs, metrics, traces, frontend monitoring, pipelines, and LLM observability.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- Bilingual new project parity check passed.
- Branch rebased on latest origin/main and origin/main is an ancestor of HEAD.
- Diff is limited to README.md and README.zh-CN.md.

## Risk
- Low: documentation-only curation update.
- Main risk is category fit drift; both entries were placed under LLM and Agent Observability because they explicitly cover LLM DevOps/observability.

## Auto-merge intent
- Auto-merge is allowed only after PR diff review and checks are green or absent.