### PR TITLE
docs: add MCP gateway to AI operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Portkey AI Gateway](https://github.com/Portkey-AI/gateway): AI gateway for routing LLM traffic, applying guardrails, and centralizing model access for production applications.
 - [BISHENG](https://github.com/dataelement/bisheng): Open LLM DevOps platform for enterprise AI applications, with GenAI workflows, RAG, agents, model management, evaluation, datasets, and observability.
 - [OpenObserve](https://github.com/openobserve/openobserve): Open-source observability platform for logs, metrics, traces, frontend monitoring, pipelines, and LLM observability.
+- [MCP Gateway](https://github.com/IBM/mcp-context-forge): AI gateway, registry, and proxy for MCP, A2A, and API tools with centralized discovery, guardrails, and management.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,6 +86,7 @@
 - [Portkey AI Gateway](https://github.com/Portkey-AI/gateway)：AI 网关，用于路由 LLM 流量、应用护栏，并集中管理生产应用的模型访问。
 - [BISHENG](https://github.com/dataelement/bisheng)：面向企业 AI 应用的开源 LLM DevOps 平台，覆盖 GenAI 工作流、RAG、Agent、模型管理、评估、数据集和可观测性。
 - [OpenObserve](https://github.com/openobserve/openobserve)：开源可观测平台，覆盖日志、指标、链路、前端监控、流水线和 LLM 可观测性。
+- [MCP Gateway](https://github.com/IBM/mcp-context-forge)：面向 MCP、A2A 和 API 工具的 AI 网关、注册表与代理，支持集中发现、护栏和管理。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Add MCP Gateway to the LLM and Agent Observability section in both English and Simplified Chinese READMEs.
- Keep the daily curation scope focused on production AI operations and MCP/A2A/API tool governance.

## Projects or content added
- MCP Gateway (`IBM/mcp-context-forge`): AI gateway, registry, and proxy for MCP, A2A, and API tools with centralized discovery, guardrails, and management.

## Validation
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese READMEs contain the same new project URL.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Branch was rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.

## Risk
- Low docs-only risk; description is intentionally concise to avoid over-claiming project capabilities.

## Auto-merge intent
- Auto-merge is allowed only if PR diff remains docs-only and checks are green or absent.
