### PR TITLE
docs: rename AI infrastructure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This list focuses on tools that help teams build, run, observe, secure, and opti
 ## Featured Maps
 
 - [LLM and Agent Observability Stack](#llm-and-agent-observability): tracing, prompt monitoring, evaluation, feedback, and production telemetry for LLM and agent systems.
-- [AI Data and Search Infrastructure](#ai-data-and-search-infrastructure): web crawling, AI-ready extraction, search intelligence, and RAG data acquisition.
+- [AI Infrastructure](#ai-infrastructure): web crawling, AI-ready extraction, search intelligence, and RAG data acquisition.
 - [Platform Engineering Stack](#platform-engineering): internal developer platforms, IAM, IaC, artifacts, API tooling, CI/CD, and testing.
 - [GitOps and Kubernetes Operations Stack](#kubernetes-operations): cluster networking, autoscaling, deployment, and runtime operations.
 - [FinOps Stack](#finops): cloud and Kubernetes cost visibility, allocation, and forecasting.
@@ -96,7 +96,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [PostHog](https://github.com/PostHog/posthog): Open-source product analytics platform for user behavior tracking and product metrics.
 - [SREWorks](https://github.com/alibaba/SREWorks): Cloud-native DataOps and AIOps platform for operating Kubernetes-based applications and infrastructure.
 
-## AI Data and Search Infrastructure
+## AI Infrastructure
 
 Infrastructure for web crawling, AI-ready extraction, search intelligence, and RAG data acquisition workflows.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,7 +17,7 @@
 ## 精选地图
 
 - [LLM 和 Agent 可观测性栈](#llm-和-agent-可观测性)：面向 LLM 与 Agent 系统的追踪、Prompt 监控、评估、反馈和生产遥测。
-- [AI 数据与搜索基础设施](#ai-数据与搜索基础设施)：Web 爬取、AI 友好抽取、搜索情报和 RAG 数据采集。
+- [AI 基础设施](#ai-基础设施)：Web 爬取、AI 友好抽取、搜索情报和 RAG 数据采集。
 - [平台工程栈](#platform-engineering-平台工程)：内部开发者平台、IAM、IaC、制品、API 工具、CI/CD 和测试。
 - [GitOps 与 Kubernetes 运维栈](#kubernetes-operations-kubernetes-运维)：集群网络、弹性伸缩、部署和运行时运维。
 - [FinOps 栈](#finops)：云和 Kubernetes 成本可见性、分摊与预测。
@@ -96,7 +96,7 @@
 - [PostHog](https://github.com/PostHog/posthog)：开源产品分析平台，支持用户行为追踪和产品指标分析。
 - [SREWorks](https://github.com/alibaba/SREWorks)：云原生 DataOps 与 AIOps 平台，用于运维 Kubernetes 应用和基础设施。
 
-## AI 数据与搜索基础设施
+## AI 基础设施
 
 用于 Web 爬取、AI 友好抽取、搜索情报和 RAG 数据采集工作流的基础设施。
 


### PR DESCRIPTION
## Summary
- Rename the AI category from `AI Data and Search Infrastructure` to the shorter `AI Infrastructure`.
- Sync the Simplified Chinese README heading and featured map anchor.

## Validation
- Ran structural Markdown validation for internal links, heading anchors, duplicate URLs, and duplicate entry names.
- Verified the diff only touches `README.md` and `README.zh-CN.md`.
- Rebased on latest `origin/main` before push.

## Risk
- Documentation-only rename; no project entries changed.