### PR TITLE
docs: add LLM guardrails and AI gateway tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [BISHENG](https://github.com/dataelement/bisheng): Open LLM DevOps platform for enterprise AI applications, with GenAI workflows, RAG, agents, model management, evaluation, datasets, and observability.
 - [OpenObserve](https://github.com/openobserve/openobserve): Open-source observability platform for logs, metrics, traces, frontend monitoring, pipelines, and LLM observability.
 - [MCP Gateway](https://github.com/IBM/mcp-context-forge): AI gateway, registry, and proxy for MCP, A2A, and API tools with centralized discovery, guardrails, and management.
+- [NVIDIA NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails): Toolkit for adding programmable safety, dialog, and policy guardrails to LLM-based conversational systems.
+- [Llama Guard](https://github.com/meta-llama/PurpleLlama): Meta's open trust and safety toolkit for evaluating and filtering LLM inputs, outputs, and model risks.
+- [OpenEvals](https://github.com/langchain-ai/openevals): Ready-made evaluators for testing and regression-checking LLM applications in development and CI workflows.
+- [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway): Envoy-based gateway for managing unified access to generative AI services across providers and platforms.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,6 +88,10 @@
 - [BISHENG](https://github.com/dataelement/bisheng)：面向企业 AI 应用的开源 LLM DevOps 平台，覆盖 GenAI 工作流、RAG、Agent、模型管理、评估、数据集和可观测性。
 - [OpenObserve](https://github.com/openobserve/openobserve)：开源可观测平台，覆盖日志、指标、链路、前端监控、流水线和 LLM 可观测性。
 - [MCP Gateway](https://github.com/IBM/mcp-context-forge)：面向 MCP、A2A 和 API 工具的 AI 网关、注册表与代理，支持集中发现、护栏和管理。
+- [NVIDIA NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails)：用于为基于 LLM 的对话系统加入可编程安全、对话和策略护栏的工具包。
+- [Llama Guard](https://github.com/meta-llama/PurpleLlama)：Meta 开源的信任与安全工具集，用于评估和过滤 LLM 输入、输出与模型风险。
+- [OpenEvals](https://github.com/langchain-ai/openevals)：现成的评估器集合，用于在开发和 CI 流程中测试 LLM 应用并做回归检查。
+- [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway)：基于 Envoy 的 AI 网关，用于跨供应商和平台统一管理生成式 AI 服务访问。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Add production-focused LLM guardrails, LLM safety evaluation, EvalOps, and AI gateway entries.
- Update both English and Simplified Chinese READMEs with matching project coverage.

## Projects or content added
- NVIDIA NeMo Guardrails: programmable guardrails for LLM conversational systems.
- Llama Guard: LLM trust and safety evaluation/filtering via Meta PurpleLlama.
- OpenEvals: ready-made evaluators for LLM application regression checks.
- Envoy AI Gateway: Envoy-based unified access layer for generative AI services.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- Bilingual expected-entry check passed for both README files.
- Diff scope verified as README.md and README.zh-CN.md only.
- Branch rebased onto latest origin/main and origin/main is an ancestor of HEAD.

## Risk
- Low docs-only risk; entries are adjacent to existing LLM observability/gateway coverage, so future category refinement may split AI safety and gateway tooling into subgroups.

## Auto-merge intent
- Auto-merge is allowed only after PR diff review and checks are green or absent.
