### PR TITLE
docs: add AI gateway operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Llama Guard](https://github.com/meta-llama/PurpleLlama): Meta's open trust and safety toolkit for evaluating and filtering LLM inputs, outputs, and model risks.
 - [OpenEvals](https://github.com/langchain-ai/openevals): Ready-made evaluators for testing and regression-checking LLM applications in development and CI workflows.
 - [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway): Envoy-based gateway for managing unified access to generative AI services across providers and platforms.
+- [Microsoft MCP Gateway](https://github.com/microsoft/mcp-gateway): Reverse proxy and management layer for operating MCP servers with session-aware routing and Kubernetes lifecycle support.
+- [CoAI](https://github.com/coaidev/coai): Multi-tenant AI platform with a unified LLM gateway, provider routing, cost management, billing, and model cache for enterprise deployments.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,6 +92,8 @@
 - [Llama Guard](https://github.com/meta-llama/PurpleLlama)：Meta 开源的信任与安全工具集，用于评估和过滤 LLM 输入、输出与模型风险。
 - [OpenEvals](https://github.com/langchain-ai/openevals)：现成的评估器集合，用于在开发和 CI 流程中测试 LLM 应用并做回归检查。
 - [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway)：基于 Envoy 的 AI 网关，用于跨供应商和平台统一管理生成式 AI 服务访问。
+- [Microsoft MCP Gateway](https://github.com/microsoft/mcp-gateway)：用于运维 MCP Server 的反向代理与管理层，支持会话感知路由和 Kubernetes 生命周期管理。
+- [CoAI](https://github.com/coaidev/coai)：多租户 AI 平台，提供统一 LLM 网关、供应商路由、成本管理、计费和模型缓存，适合企业级部署。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Add two AI gateway / MCP operations projects to the LLM and Agent Observability section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- Microsoft MCP Gateway: reverse proxy and management layer for operating MCP servers with session-aware routing and Kubernetes lifecycle support.
- CoAI: multi-tenant AI platform with unified LLM gateway, provider routing, cost management, billing, and model cache.

## Validation
- `gh issue list` found no open actionable issues, so daily curation ran.
- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- Bilingual new-entry parity check passed.
- Diff scope verified: only `README.md` and `README.zh-CN.md` changed.
- Branch rebased on latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Push verification passed: remote branch matches local HEAD.

## Risk
- Low: documentation-only change.
- Main curation risk is category drift; both entries are kept in AI/LLM operations because they focus on gateway, routing, lifecycle, and cost controls rather than generic app demos.

## Auto-merge intent
- Auto-merge is allowed if PR diff is clean and checks are green or absent. Will inspect PR diff and checks before merging.
