### PR TITLE
docs: add AI inference serving operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Microsoft MCP Gateway](https://github.com/microsoft/mcp-gateway): Reverse proxy and management layer for operating MCP servers with session-aware routing and Kubernetes lifecycle support.
 - [CoAI](https://github.com/coaidev/coai): Multi-tenant AI platform with a unified LLM gateway, provider routing, cost management, billing, and model cache for enterprise deployments.
 
+## AI Serving and Inference Operations
+
+Tools for deploying, scaling, routing, and operating AI model inference workloads in production.
+
+- [Ray Serve](https://github.com/ray-project/ray): Scalable model serving library in Ray for building distributed online inference APIs and LLM serving workloads.
+- [Triton Inference Server](https://github.com/triton-inference-server/server): Optimized inference server for deploying AI models across GPUs, CPUs, and cloud or edge environments.
+- [KServe](https://github.com/kserve/kserve): Kubernetes-native platform for standardized, scalable generative and predictive AI inference serving.
+- [AIBrix](https://github.com/vllm-project/aibrix): Cloud-native infrastructure components for cost-efficient, scalable GenAI and LLM inference operations.
+
 ## AIOps
 
 - [Netdata](https://github.com/netdata/netdata): Distributed real-time monitoring for infrastructure metrics, visualization, and alerting.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,6 +95,15 @@
 - [Microsoft MCP Gateway](https://github.com/microsoft/mcp-gateway)：用于运维 MCP Server 的反向代理与管理层，支持会话感知路由和 Kubernetes 生命周期管理。
 - [CoAI](https://github.com/coaidev/coai)：多租户 AI 平台，提供统一 LLM 网关、供应商路由、成本管理、计费和模型缓存，适合企业级部署。
 
+## AI Serving and Inference Operations AI 推理服务运维
+
+用于在生产环境部署、扩缩容、路由和运维 AI 模型推理负载的工具。
+
+- [Ray Serve](https://github.com/ray-project/ray)：Ray 中的可扩展模型服务库，用于构建分布式在线推理 API 和 LLM 服务负载。
+- [Triton Inference Server](https://github.com/triton-inference-server/server)：优化的推理服务器，用于在 GPU、CPU、云端和边缘环境部署 AI 模型。
+- [KServe](https://github.com/kserve/kserve)：Kubernetes 原生平台，用于标准化、可扩展地服务生成式和预测式 AI 推理。
+- [AIBrix](https://github.com/vllm-project/aibrix)：云原生基础设施组件，用于高性价比、可扩展地运维 GenAI 和 LLM 推理。
+
 ## AIOps 智能运维
 
 - [Netdata](https://github.com/netdata/netdata)：分布式实时监控系统，提供基础设施指标收集、可视化和告警功能。


### PR DESCRIPTION
## Summary
- Add a new AI Serving and Inference Operations section to strengthen the production AI operations map.
- Add mature inference-serving infrastructure projects to both English and Simplified Chinese READMEs.

## Projects or content added
- Ray Serve — scalable distributed online inference and LLM serving on Ray.
- Triton Inference Server — optimized AI inference serving across GPU, CPU, cloud, and edge environments.
- KServe — Kubernetes-native standardized generative and predictive inference serving.
- AIBrix — cloud-native infrastructure components for cost-efficient GenAI/LLM inference operations.

## Validation
- `gh issue list --repo xlabs-club/awesome-x-ops --state open --limit 20 --json number,title,createdAt,author,url` returned no open issues, so curation path was used.
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- Bilingual project parity check passed for Ray Serve, Triton Inference Server, KServe, and AIBrix.
- Diff scope verified: only `README.md` and `README.zh-CN.md` changed.
- Rebased on latest `origin/main`; verified `origin/main` is an ancestor of HEAD.
- Remote branch SHA verified to match local HEAD after push.

## Risk
- The new section broadens AI operations coverage from observability/gateways into inference serving; this is intentional but should stay curated to avoid becoming a generic ML framework list.
- Ray Serve is linked via the Ray monorepo, so future sorting or metadata automation should treat it as a component-level entry.

## Auto-merge intent
- Auto-merge is allowed if PR self-review remains clean and repository checks are green or absent.
