### PR TITLE
docs: add Inference Gateway to LLM operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [LLM Guard](https://github.com/protectai/llm-guard): Security toolkit for sanitizing LLM inputs and outputs, detecting prompt injection, blocking harmful content, and reducing data leakage.
 - [OpenEvals](https://github.com/langchain-ai/openevals): Ready-made evaluators for testing and regression-checking LLM applications in development and CI workflows.
 - [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway): Envoy-based gateway for managing unified access to generative AI services across providers and platforms.
+- [Inference Gateway](https://github.com/inference-gateway/inference-gateway): Cloud-native LLM gateway for unifying providers, routing inference traffic, and exposing OpenTelemetry-friendly operations on Kubernetes.
 - [OneAIFW](https://github.com/funstory-ai/aifw): Lightweight local AI firewall for anonymizing sensitive data before LLM calls and restoring it after responses.
 - [Microsoft MCP Gateway](https://github.com/microsoft/mcp-gateway): Reverse proxy and management layer for operating MCP servers with session-aware routing and Kubernetes lifecycle support.
 - [CoAI](https://github.com/coaidev/coai): Multi-tenant AI platform with a unified LLM gateway, provider routing, cost management, billing, and model cache for enterprise deployments.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,6 +93,7 @@
 - [LLM Guard](https://github.com/protectai/llm-guard)：LLM 交互安全工具包，用于清洗输入输出、检测 Prompt 注入、拦截有害内容并降低数据泄露风险。
 - [OpenEvals](https://github.com/langchain-ai/openevals)：现成的评估器集合，用于在开发和 CI 流程中测试 LLM 应用并做回归检查。
 - [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway)：基于 Envoy 的 AI 网关，用于跨供应商和平台统一管理生成式 AI 服务访问。
+- [Inference Gateway](https://github.com/inference-gateway/inference-gateway)：云原生 LLM 网关，用于统一模型供应商、路由推理流量，并在 Kubernetes 上提供 OpenTelemetry 友好的运维能力。
 - [OneAIFW](https://github.com/funstory-ai/aifw)：轻量级本地 AI 防火墙，可在调用 LLM 前匿名化敏感数据，并在响应后还原。
 - [Microsoft MCP Gateway](https://github.com/microsoft/mcp-gateway)：用于运维 MCP Server 的反向代理与管理层，支持会话感知路由和 Kubernetes 生命周期管理。
 - [CoAI](https://github.com/coaidev/coai)：多租户 AI 平台，提供统一 LLM 网关、供应商路由、成本管理、计费和模型缓存，适合企业级部署。


### PR DESCRIPTION
## Summary
- Add Inference Gateway to the LLM and Agent Observability section in both English and Simplified Chinese READMEs.
- Keep the change docs-only and focused on production LLM gateway operations.

## Projects or content added
- Inference Gateway: cloud-native LLM gateway for unified provider access, inference routing, Kubernetes operation, and OpenTelemetry-friendly tracing.

## Validation
- Ran Markdown structural checks for internal links, duplicate URLs, duplicate entry names, and bilingual presence of the new entry.
- Verified changed files are limited to README.md and README.zh-CN.md.
- Rebasing/freshness check passed: origin/main is an ancestor of the branch HEAD before push.

## Risk
- Low: documentation-only addition.
- Curation risk: project is younger and lower-star than major gateways, but it is active, Apache-2.0, recently released, Kubernetes-oriented, and directly relevant to production LLM gateway operations.

## Auto-merge intent
- Auto-merge is allowed only if PR diff remains docs-only and checks are green or absent.
