### PR TITLE
docs: add AI inference operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [Triton Inference Server](https://github.com/triton-inference-server/server): Optimized inference server for deploying AI models across GPUs, CPUs, and cloud or edge environments.
 - [KServe](https://github.com/kserve/kserve): Kubernetes-native platform for standardized, scalable generative and predictive AI inference serving.
 - [AIBrix](https://github.com/vllm-project/aibrix): Cloud-native infrastructure components for cost-efficient, scalable GenAI and LLM inference operations.
+- [Dynamo](https://github.com/ai-dynamo/dynamo): Distributed inference serving framework for datacenter-scale LLM and generative AI workloads with Kubernetes-oriented routing and scaling.
+- [dstack](https://github.com/dstackai/dstack): Vendor-agnostic control plane for provisioning GPUs and orchestrating training, inference, and agent workloads across clouds, Kubernetes, and bare metal.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,6 +106,8 @@
 - [Triton Inference Server](https://github.com/triton-inference-server/server)：优化的推理服务器，用于在 GPU、CPU、云端和边缘环境部署 AI 模型。
 - [KServe](https://github.com/kserve/kserve)：Kubernetes 原生平台，用于标准化、可扩展地服务生成式和预测式 AI 推理。
 - [AIBrix](https://github.com/vllm-project/aibrix)：云原生基础设施组件，用于高性价比、可扩展地运维 GenAI 和 LLM 推理。
+- [Dynamo](https://github.com/ai-dynamo/dynamo)：面向数据中心规模 LLM 与生成式 AI 负载的分布式推理服务框架，支持 Kubernetes 场景下的路由和扩缩容。
+- [dstack](https://github.com/dstackai/dstack)：供应商无关的 GPU 供应与编排控制平面，可跨云、Kubernetes 和裸金属运行训练、推理与 Agent 工作负载。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Add two production-oriented AI inference operations projects to the AI Serving and Inference Operations section.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- Dynamo: distributed inference serving for datacenter-scale LLM and generative AI workloads.
- dstack: vendor-agnostic GPU provisioning and orchestration for training, inference, and agent workloads.

## Validation
- `python3` markdown structural checks: passed.
- New project parity check across `README.md` and `README.zh-CN.md`: passed.
- Changed files limited to `README.md` and `README.zh-CN.md`.
- Branch rebased on latest `origin/main`; `origin/main` verified as ancestor of HEAD.
- Remote branch SHA verified to match local HEAD.

## Risk
- Low docs-only risk.
- Main curation risk is category fit drift; both entries are scoped to AI inference operations, not generic AI demos.

## Auto-merge intent
- Auto-merge is allowed if PR diff remains docs-only and checks are green or absent.
