### PR TITLE
docs: add Kubernetes AI inference operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [AIBrix](https://github.com/vllm-project/aibrix): Cloud-native infrastructure components for cost-efficient, scalable GenAI and LLM inference operations.
 - [Dynamo](https://github.com/ai-dynamo/dynamo): Distributed inference serving framework for datacenter-scale LLM and generative AI workloads with Kubernetes-oriented routing and scaling.
 - [dstack](https://github.com/dstackai/dstack): Vendor-agnostic control plane for provisioning GPUs and orchestrating training, inference, and agent workloads across clouds, Kubernetes, and bare metal.
+- [llm-d](https://github.com/llm-d/llm-d): Kubernetes-native distributed inference stack for high-performance LLM serving with intelligent routing on modern accelerators.
+- [KubeAI](https://github.com/kubeai-project/kubeai): Kubernetes AI inference operator for serving LLMs, VLMs, embeddings, and speech models with OpenAI-compatible APIs.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,6 +108,8 @@
 - [AIBrix](https://github.com/vllm-project/aibrix)：云原生基础设施组件，用于高性价比、可扩展地运维 GenAI 和 LLM 推理。
 - [Dynamo](https://github.com/ai-dynamo/dynamo)：面向数据中心规模 LLM 与生成式 AI 负载的分布式推理服务框架，支持 Kubernetes 场景下的路由和扩缩容。
 - [dstack](https://github.com/dstackai/dstack)：供应商无关的 GPU 供应与编排控制平面，可跨云、Kubernetes 和裸金属运行训练、推理与 Agent 工作负载。
+- [llm-d](https://github.com/llm-d/llm-d)：Kubernetes 原生分布式推理栈，面向现代加速器上的高性能 LLM 服务和智能路由。
+- [KubeAI](https://github.com/kubeai-project/kubeai)：Kubernetes AI 推理 Operator，用 OpenAI 兼容 API 服务 LLM、VLM、Embedding 和语音模型。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary
- Add two Kubernetes-native AI inference operations projects to the AI Serving and Inference Operations section.
- Update both English and Simplified Chinese README entries with equivalent descriptions.

## Projects or content added
- llm-d: Kubernetes-native distributed inference stack for high-performance LLM serving with intelligent routing.
- KubeAI: Kubernetes AI inference operator for LLMs, VLMs, embeddings, and speech models with OpenAI-compatible APIs.

## Validation
- `gh issue list --state open` returned no open issues, so curation workflow was used.
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- Bilingual parity checked for the new entries.
- Rebased on latest `origin/main`; verified `origin/main` is an ancestor of HEAD.
- Diff scope checked: only `README.md` and `README.zh-CN.md` changed.
- Push verified: local HEAD matches remote branch HEAD.

## Risk
- Low: documentation-only change.
- Main curation risk is list growth noise; both projects were selected for production AI inference operations relevance, active maintenance, Apache-2.0 licensing, and GitHub ecosystem signal.

## Auto-merge intent
- Auto-merge is allowed if PR diff remains docs-only and checks are green or absent after review.
