### PR TITLE
docs: add LLM Knowledge category and Tencent/WeKnora

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This list focuses on tools that help teams build, run, observe, secure, and opti
 ## Featured Maps
 
 - [LLM and Agent Observability Stack](#llm-and-agent-observability): tracing, prompt monitoring, evaluation, feedback, and production telemetry for LLM and agent systems.
+- [LLM Knowledge](#llm-knowledge): open-source platforms for turning documents into RAG knowledge bases, autonomous reasoning agents, and self-maintaining wikis.
 - [AI Infrastructure](#ai-infrastructure): web crawling, AI-ready extraction, search intelligence, and RAG data acquisition.
 - [Platform Engineering Stack](#platform-engineering): internal developer platforms, IAM, IaC, artifacts, API tooling, CI/CD, and testing.
 - [GitOps and Kubernetes Operations Stack](#kubernetes-operations): cluster networking, autoscaling, deployment, and runtime operations.
@@ -131,6 +132,16 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Firecrawl](https://github.com/firecrawl/firecrawl): Web search, scraping, crawling, and extraction API that turns web data into LLM-ready Markdown and structured outputs.
 - [Crawl4AI](https://github.com/unclecode/crawl4ai): Open-source LLM-friendly web crawler and scraper for building RAG, agent, and web data pipelines.
 - [Open SEO](https://github.com/every-app/open-seo): Open-source SEO and search intelligence platform for keyword research, site audits, backlink analysis, and Google Search Console MCP workflows.
+
+## LLM Knowledge
+
+Open-source platforms for building, managing, and querying LLM-powered knowledge bases from unstructured documents.
+
+- [RAGFlow](https://github.com/infiniflow/ragflow): Leading open-source RAG engine that combines deep document understanding, knowledge base management, and agent capabilities for enterprise knowledge workflows.
+- [FastGPT](https://github.com/labring/FastGPT): Knowledge-based LLM application platform with out-of-the-box data processing, model invocation, RAG, and visual workflow orchestration.
+- [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm): Local-first document chat and agent platform that turns any document into a context-aware LLM knowledge base.
+- [WeKnora](https://github.com/Tencent/WeKnora): Open-source LLM knowledge platform that turns raw documents into a queryable RAG, an autonomous reasoning agent, and a self-maintaining Wiki.
+- [MaxKB](https://github.com/1Panel-dev/MaxKB): Open-source enterprise platform for building knowledge base agents with RAG, multi-model support, and visual workflow design.
 
 ## Agentic Workflow
 
@@ -268,6 +279,10 @@ A curated technology stack and toolchain for platform engineering.
 - [Tekton](https://tekton.dev/): Kubernetes-native CI/CD framework with flexible task orchestration.
 - [Flux](https://fluxcd.io/): Popular Kubernetes GitOps toolkit.
 - [PipeCD](https://github.com/pipe-cd/pipecd): CNCF continuous delivery platform for applications, infrastructure, and platform operations across multiple deployment targets.
+
+### Code Search and Understanding
+
+- [sourcebot](https://github.com/sourcebot-dev/sourcebot): Self-hosted code search and understanding tool for humans and AI agents to navigate, query, and comprehend large codebases.
 
 ### Code Service
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,7 @@
 ## 精选地图
 
 - [LLM 和 Agent 可观测性栈](#llm-和-agent-可观测性)：面向 LLM 与 Agent 系统的追踪、Prompt 监控、评估、反馈和生产遥测。
+- [LLM 知识库](#llm-知识库)：将文档转化为 RAG 知识库、自主推理 Agent 和自维护 Wiki 的开源平台。
 - [AI 基础设施](#ai-基础设施)：Web 爬取、AI 友好抽取、搜索情报和 RAG 数据采集。
 - [平台工程栈](#platform-engineering-平台工程)：内部开发者平台、IAM、IaC、制品、API 工具、CI/CD 和测试。
 - [GitOps 与 Kubernetes 运维栈](#kubernetes-operations-kubernetes-运维)：集群网络、弹性伸缩、部署和运行时运维。
@@ -131,6 +132,16 @@
 - [Firecrawl](https://github.com/firecrawl/firecrawl)：Web 搜索、抓取、爬取与抽取 API，可将网页数据转换为适合 LLM 使用的 Markdown 和结构化输出。
 - [Crawl4AI](https://github.com/unclecode/crawl4ai)：面向 LLM 的开源 Web 爬虫与抓取工具，适合构建 RAG、Agent 和 Web 数据流水线。
 - [Open SEO](https://github.com/every-app/open-seo)：开源 SEO 与搜索情报平台，支持关键词研究、站点审计、反向链接分析和 Google Search Console MCP 工作流。
+
+## LLM 知识库
+
+用于从非结构化文档构建、管理和查询 LLM 知识库的开源平台。
+
+- [RAGFlow](https://github.com/infiniflow/ragflow)：领先的开源 RAG 引擎，融合深度文档理解、知识库管理和 Agent 能力，适合企业知识工作流。
+- [FastGPT](https://github.com/labring/FastGPT)：基于 LLM 的知识库应用平台，提供开箱即用的数据处理、模型调用、RAG 和可视化工作流编排。
+- [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)：本地优先的文档对话和 Agent 平台，可将任意文档转化为上下文感知的 LLM 知识库。
+- [WeKnora](https://github.com/Tencent/WeKnora)：开源 LLM 知识平台，可将原始文档转化为可查询的 RAG、自主推理 Agent 和自维护 Wiki。
+- [MaxKB](https://github.com/1Panel-dev/MaxKB)：开源企业级智能体平台，支持基于知识库的 RAG、多模型接入和可视化工作流设计。
 
 ## Agentic Workflow 智能体工作流
 
@@ -268,6 +279,10 @@
 - [Tekton](https://tekton.dev/)：Kubernetes 原生 CI/CD 框架，提供灵活的任务编排能力。
 - [Flux](https://fluxcd.io/)：流行的 Kubernetes GitOps 工具包。
 - [PipeCD](https://github.com/pipe-cd/pipecd)：CNCF 持续交付平台，支持跨多种部署目标管理应用、基础设施和平台运维。
+
+### Code Search and Understanding 代码搜索与理解
+
+- [sourcebot](https://github.com/sourcebot-dev/sourcebot)：自托管的代码搜索与理解工具，帮助人类和 AI Agent 导航、查询和理解大型代码库。
 
 ### Code Service 代码服务
 


### PR DESCRIPTION
## Summary
Add a new **LLM Knowledge** category + **Code Search and Understanding** subcategory under Platform Engineering.

## LLM Knowledge (new category)
| Project | Stars | Description |
|---------|-------|-------------|
| [RAGFlow](https://github.com/infiniflow/ragflow) | 84.4k | Leading open-source RAG engine |
| [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm) | 62.7k | Local-first document chat and agent platform |
| [FastGPT](https://github.com/labring/FastGPT) | 28.8k | Knowledge-based LLM application platform |
| [MaxKB](https://github.com/1Panel-dev/MaxKB) | 21.9k | Enterprise knowledge base agent platform |
| [WeKnora](https://github.com/Tencent/WeKnora) | 17.9k | Document-to-RAG knowledge platform |

## Code Search and Understanding (new subcategory)
| Project | Stars | Description |
|---------|-------|-------------|
| [sourcebot](https://github.com/sourcebot-dev/sourcebot) | 3.6k | Self-hosted code search for humans and AI agents |

## Category placement
```
... → AI Infrastructure → LLM Knowledge (NEW) → Agentic Workflow → ...
```
```
Platform Engineering → Code Search (NEW) → Code Service → ...
```

## Changed files
- `README.md`: +15 lines
- `README.zh-CN.md`: +15 lines

## Validation
- [x] Both READMEs updated consistently
- [x] No duplicate URLs or entries
- [x] All 6 new entries present in both files
- [x] Sort order: RAGFlow → AnythingLLM → FastGPT → MaxKB → WeKnora (by stars, then keep WeKnora last as the wiki-oriented entry)