### PR TITLE
docs: add LLM evaluation, AI coding tools, and AI code review (sprint curation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Weights & Biases](https://github.com/wandb/wandb): AI developer platform for experiment tracking, model management, and monitoring ML/LLM workflows from training to production.
 - [ClearML](https://github.com/clearml/clearml): Open-source MLOps/LLMOps platform for experiment management, data pipelines, orchestration, and model serving.
 - [Helicone AI Gateway](https://github.com/Helicone/ai-gateway): Fast, lightweight Rust-based AI gateway with smart routing, caching, rate limiting, and built-in observability across 100+ LLM providers.
+- [EleutherAI LM Eval](https://github.com/EleutherAI/lm-evaluation-harness): Standardized framework for few-shot and zero-shot evaluation of language models across hundreds of tasks and benchmarks.
+- [Weave](https://github.com/wandb/weave): Toolkit for tracing, evaluating, and improving LLM applications with automatic versioning and interactive debugging workflows.
+- [Pezzo](https://github.com/pezzolabs/pezzo): Open-source LLMOps platform for prompt management, version control, A/B testing, troubleshooting, and observability.
 
 ## AI Serving and Inference Operations
 
@@ -149,6 +152,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory): Unified framework for LLM fine-tuning with 100+ models and 50+ methods, supporting LoRA, QLoRA, and full-parameter training with web UI workflows.
 - [Unsloth](https://github.com/unslothai/unsloth): Open-source library for 2-5x faster LLM fine-tuning with significant memory reduction, supporting major model architectures and training workflows.
 - [HAMi](https://github.com/Project-HAMi/HAMi): Heterogeneous GPU sharing middleware for Kubernetes with device memory isolation and multi-tenant scheduling.
+- [Llama Deploy](https://github.com/run-llama/llama_deploy): Production deployment framework for LlamaIndex agentic workflows with asynchronous task orchestration and service management.
 
 ## AIOps
 
@@ -385,6 +389,12 @@ A curated technology stack and toolchain for platform engineering.
 
 - [sourcebot](https://github.com/sourcebot-dev/sourcebot): Self-hosted code search and understanding tool for humans and AI agents to navigate, query, and comprehend large codebases.
 
+### AI Coding Tools
+
+- [Aider](https://github.com/Aider-AI/aider): AI pair programming tool that works in your terminal with multi-file editing, git integration, and support for leading LLMs.
+- [Continue](https://github.com/continuedev/continue): Open-source AI code assistant that integrates with IDEs as an autopilot for software development with customizable context and models.
+- [Tabby](https://github.com/TabbyML/tabby): Self-hosted AI coding assistant with code completion, chat, and agent capabilities that can run fully on-premises.
+
 ### Developer Environments
 
 - [Coder](https://github.com/coder/coder): Self-hosted remote development platform for provisioning secure, pre-configured workspaces for developers and AI agents on any infrastructure.
@@ -396,6 +406,7 @@ A curated technology stack and toolchain for platform engineering.
 - [SonarQube](https://github.com/SonarSource/sonarqube): Continuous code quality platform supporting 27+ programming languages.
 - [Open Code Review](https://github.com/alibaba/open-code-review): Open-source hybrid code review tool combining deterministic pipelines with LLM agents for precise, line-level feedback at scale.
 - [reviewdog](https://github.com/reviewdog): Automated code review and analysis tool for many languages and linters.
+- [PR-Agent](https://github.com/The-PR-Agent/pr-agent): Open-source AI-powered PR reviewer for automated code review, description generation, and improvement suggestions across git platforms.
 - [Dependency Track](https://dependencytrack.org/): Open-source software component analysis platform for supply-chain risk, SBOM analysis, and license checks.
 - [OpenRewrite](https://docs.openrewrite.org): Automated large-scale code refactoring and modernization tool.
 - [Hyades](https://github.com/DependencyTrack/hyades): Next-generation software supply-chain security platform intended to replace Dependency-Track after stabilization.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,6 +115,9 @@
 - [Weights & Biases](https://github.com/wandb/wandb)：AI 开发者平台，提供实验追踪、模型管理和 ML/LLM 工作流监控，覆盖从训练到生产的全流程。
 - [ClearML](https://github.com/clearml/clearml)：开源 MLOps/LLMOps 平台，支持实验管理、数据流水线、编排和模型服务。
 - [Helicone AI Gateway](https://github.com/Helicone/ai-gateway)：基于 Rust 构建的快速轻量 AI 网关，支持智能路由、缓存、速率限制和内置可观测性，覆盖 100+ LLM 供应商。
+- [EleutherAI LM Eval](https://github.com/EleutherAI/lm-evaluation-harness)：用于语言模型的标准化 few-shot 和 zero-shot 评估框架，覆盖数百个任务和基准测试。
+- [Weave](https://github.com/wandb/weave)：用于追踪、评估和改进 LLM 应用的工具包，支持自动版本控制和交互式调试工作流。
+- [Pezzo](https://github.com/pezzolabs/pezzo)：开源 LLMOps 平台，支持 Prompt 管理、版本控制、A/B 测试、故障排查和可观测性。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 
@@ -149,6 +152,7 @@
 - [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory)：统一 LLM 微调框架，支持 100+ 模型和 50+ 方法，涵盖 LoRA、QLoRA 和全参数训练，提供 Web UI 工作流。
 - [Unsloth](https://github.com/unslothai/unsloth)：开源 LLM 微调加速库，可将微调速度提升 2-5 倍并显著降低内存占用，支持主流模型架构与训练工作流。
 - [HAMi](https://github.com/Project-HAMi/HAMi)：异构 GPU 共享中间件，支持 Kubernetes 上的 GPU 显存隔离、设备复用和多租户调度。
+- [Llama Deploy](https://github.com/run-llama/llama_deploy)：面向 LlamaIndex Agent 工作流的生产部署框架，支持异步任务编排和服务管理。
 
 ## AIOps 智能运维
 
@@ -385,6 +389,12 @@
 
 - [sourcebot](https://github.com/sourcebot-dev/sourcebot)：自托管的代码搜索与理解工具，帮助人类和 AI Agent 导航、查询和理解大型代码库。
 
+### AI Coding Tools AI 编码工具
+
+- [Aider](https://github.com/Aider-AI/aider)：终端中的 AI 结对编程工具，支持多文件编辑、Git 集成和主流 LLM。
+- [Continue](https://github.com/continuedev/continue)：开源 AI 代码助手，以自动驾驶模式集成到 IDE 中，支持自定义上下文和模型。
+- [Tabby](https://github.com/TabbyML/tabby)：自托管的 AI 编码助手，提供代码补全、对话和 Agent 能力，可完全在本地运行。
+
 ### Developer Environments 开发环境
 
 - [Coder](https://github.com/coder/coder)：自托管远程开发平台，可在任意基础设施上为开发者和 AI Agent 配置安全、预配置的工作空间。
@@ -396,6 +406,7 @@
 - [SonarQube](https://github.com/SonarSource/sonarqube)：持续代码质量平台，支持 27+ 编程语言。
 - [Open Code Review](https://github.com/alibaba/open-code-review)：阿里巴巴开源混合代码审查工具，结合确定性流水线与 LLM Agent，提供精确的行级审查反馈。
 - [reviewdog](https://github.com/reviewdog)：自动代码审查和分析工具，支持多种语言和 linter。
+- [PR-Agent](https://github.com/The-PR-Agent/pr-agent)：开源的 AI 驱动 PR 审查工具，支持自动代码审查、描述生成和跨 Git 平台的优化建议。
 - [Dependency Track](https://dependencytrack.org/)：开源软件组件分析平台，支持供应链风险、SBOM 和 License 检查。
 - [OpenRewrite](https://docs.openrewrite.org)：自动化大规模代码重构与现代化工具。
 - [Hyades](https://github.com/DependencyTrack/hyades)：下一代软件供应链安全平台，稳定后计划替代 Dependency-Track。


### PR DESCRIPTION
## Summary

Sprint curation run adding 8 high-signal AI Ops projects to strengthen the list's AI operations coverage.

## Projects Added

### LLM and Agent Observability (3)
- **EleutherAI LM Eval** ⭐13K — Standardized LLM evaluation framework across hundreds of tasks
- **Weave (W&B)** ⭐1.1K — LLM app tracing, evaluation, and debugging toolkit
- **Pezzo** ⭐3.3K — Open-source LLMOps platform for prompt management and observability

### AI Serving and Inference Operations (1)
- **Llama Deploy** ⭐2.1K — Production deployment framework for LlamaIndex agentic workflows

### AI Coding Tools (new subcategory under Platform Engineering) (3)
- **Aider** ⭐47K — AI pair programming in terminal
- **Continue** ⭐35K — Open-source AI code assistant for IDEs
- **Tabby** ⭐34K — Self-hosted AI coding assistant

### Code Service / AI Code Review (1)
- **PR-Agent** ⭐12K — AI-powered PR reviewer with automated code review

## Validation

- [x] Markdown structural checks pass (no duplicate URLs, no duplicate names, internal links ok)
- [x] Both README.md and README.zh-CN.md updated with equivalent entries
- [x] Branch rebased on latest origin/main
- [x] Remote branch SHA matches local HEAD
- [x] Only expected files changed (2 files, +22 lines)

## Risk

Low. All entries are well-established projects with strong community adoption. No structural changes to existing categories.

## Auto-merge

Intended. Diff is clean, docs-only, validation passes.