### PR TITLE
docs: add LLM knowledge platforms and AI coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Zep](https://github.com/getzep/zep): Open-source memory layer for AI agents providing long-term recall, user facts, and knowledge graph capabilities for persistent agent memory.
 - [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG): Open-source framework for RAG evaluation and optimization with AutoML-style automation for pipeline tuning.
 - [MemPalace](https://github.com/MemPalace/mempalace): Open-source AI memory system with best-in-class benchmarks, providing persistent knowledge storage for AI agents and LLM applications.
+- [LightRAG](https://github.com/HKUDS/LightRAG): Simple and fast RAG framework with graph-based retrieval, supporting incremental updates and efficient knowledge graph construction.
+- [Kotaemon](https://github.com/Cinnamon/kotaemon): Open-source RAG-based document QA tool with multi-model support and a customizable UI for chatting with documents.
+- [Quivr](https://github.com/QuivrHQ/quivr): Opinionated RAG platform for integrating GenAI into applications, supporting any LLM, vector store, and file type.
+- [R2R](https://github.com/sciphi-ai/r2r): Production-ready AI retrieval system with agentic RAG and a RESTful API for enterprise knowledge workflows.
 
 ## Agentic Workflow
 
@@ -412,6 +416,8 @@ A curated technology stack and toolchain for platform engineering.
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands): AI-driven development platform for automated coding, code review, and software engineering tasks with agent-based workflows.
 - [SWE-agent](https://github.com/SWE-agent/SWE-agent): LLM-powered agent that automatically resolves GitHub issues and fixes bugs with iterative, tool-using workflows.
 - [GPT-Pilot](https://github.com/Pythagora-io/gpt-pilot): AI developer that builds production-ready applications from natural language specifications with human-in-the-loop guidance.
+- [OpenAI Codex CLI](https://github.com/openai/codex): Lightweight coding agent that runs in the terminal, providing AI-powered code editing and task automation from the command line.
+- [Void](https://github.com/voideditor/void): Open-source AI code editor with intelligent code completion, editing, and agentic coding workflows in a modern editor environment.
 
 ### Developer Environments
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,6 +219,10 @@
 - [Zep](https://github.com/getzep/zep)：开源 AI Agent 记忆层，提供长期记忆召回、用户事实和知识图谱能力，实现持久的 Agent 记忆。
 - [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG)：开源 RAG 评估与优化框架，通过 AutoML 风格自动化进行流水线调优。
 - [MemPalace](https://github.com/MemPalace/mempalace)：开源 AI 记忆系统，提供基准测试最优的持久化知识存储能力，适用于 AI Agent 和 LLM 应用。
+- [LightRAG](https://github.com/HKUDS/LightRAG)：简洁高效的 RAG 框架，基于图谱检索，支持增量更新和高效知识图谱构建。
+- [Kotaemon](https://github.com/Cinnamon/kotaemon)：开源的 RAG 文档问答工具，支持多模型接入和可定制 UI，实现与文档的智能对话交互。
+- [Quivr](https://github.com/QuivrHQ/quivr)：面向应用集成的 RAG 平台，支持任意 LLM、向量存储和文件类型，让团队专注产品而非 RAG 实现细节。
+- [R2R](https://github.com/sciphi-ai/r2r)：生产就绪的 AI 检索系统，支持 Agentic RAG 和 RESTful API，适合企业级知识工作流。
 
 ## Agentic Workflow 智能体工作流
 
@@ -412,6 +416,8 @@
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands)：AI 驱动开发平台，通过 Agent 工作流实现自动化编码、代码审查和软件工程任务。
 - [SWE-agent](https://github.com/SWE-agent/SWE-agent)：基于 LLM 的智能 Agent，可自动解决 GitHub Issue 和修复 Bug，支持迭代式工具调用工作流。
 - [GPT-Pilot](https://github.com/Pythagora-io/gpt-pilot)：AI 开发者，可从自然语言规格说明构建生产就绪应用，支持人机协作引导。
+- [OpenAI Codex CLI](https://github.com/openai/codex)：轻量级终端 AI 编码 Agent，在命令行中提供 AI 驱动的代码编辑和任务自动化能力。
+- [Void](https://github.com/voideditor/void)：开源 AI 代码编辑器，提供智能代码补全、编辑和 Agent 编码工作流。
 
 ### Developer Environments 开发环境
 


### PR DESCRIPTION
## Summary

Add 6 new high-quality entries across LLM Knowledge and AI Coding Tools categories.

## Projects Added

### LLM Knowledge
- **LightRAG** (HKUDS/LightRAG, 37.5k ⭐): Simple and fast RAG framework with graph-based retrieval.
- **Kotaemon** (Cinnamon/kotaemon, 25.5k ⭐): Open-source RAG-based document QA with multi-model support.
- **Quivr** (QuivrHQ/quivr, 39.2k ⭐): Opinionated RAG platform for integrating GenAI into applications.
- **R2R** (sciphi-ai/r2r, 7.9k ⭐): Production-ready AI retrieval system with agentic RAG and RESTful API.

### AI Coding Tools
- **OpenAI Codex CLI** (openai/codex, 97.2k ⭐): Lightweight terminal coding agent.
- **Void** (voideditor/void, 28.8k ⭐): Open-source AI code editor with intelligent completion and agentic workflows.

## Validation
- Markdown structural checks: ✅ passed
- No duplicate URLs or entry names
- Bilingual consistency: English + Chinese entries aligned
- Changed files: README.md, README.zh-CN.md only

## Risk
Low. Documentation-only change, scoped to README files.

## Auto-merge Intent
Self-review passed. Squash merge after CI checks.