### PR TITLE
docs: add OpenCode, Agent-Reach, zvec, and CowAgent to AI ops catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,13 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Weaviate](https://github.com/weaviate/weaviate): Open-source vector database combining vector search with structured filtering and generative AI integrations.
 - [pgvector](https://github.com/pgvector/pgvector): Open-source vector similarity search extension for PostgreSQL, widely used for RAG and AI embedding storage.
 - [LanceDB](https://github.com/lancedb/lancedb): Developer-friendly embedded vector database for multimodal AI search with serverless architecture and zero-copy retrieval.
+- [zvec](https://github.com/alibaba/zvec): Lightweight, lightning-fast in-process vector database from Alibaba for embedded AI search and retrieval, Apache-2.0.
 - [txtai](https://github.com/neuml/txtai): All-in-one AI framework for semantic search, LLM orchestration, and language model workflows with embeddings and pipelines.
 - [Feast](https://github.com/feast-dev/feast): Open-source feature store for AI/ML that serves features consistently for model training and online inference.
 - [Instructor](https://github.com/567-labs/instructor): Structured outputs for LLMs with Pydantic validation, automatic retries, and provider-agnostic API.
 - [pgai](https://github.com/timescale/pgai): Open-source suite for building RAG, semantic search, and AI applications directly on PostgreSQL with vector and AI tooling.
 - [Browser Use](https://github.com/browser-use/browser-use): Open-source web automation toolkit that enables AI agents to browse websites, extract data, and automate online tasks at scale.
+- [Agent-Reach](https://github.com/Panniantong/Agent-Reach): Give your AI agent eyes to see the entire internet — read and search Twitter, Reddit, YouTube, GitHub, Bilibili, and more via one CLI with zero API fees.
 - [Steel Browser](https://github.com/steel-dev/steel-browser): Open-source headless browser sandbox for AI agents and applications, providing production-ready web automation infrastructure.
 - [E2B](https://github.com/e2b-dev/E2B): Open-source secure cloud sandbox for running AI agent code with isolated environments, file system access, and real-world tool execution.
 - [headroom](https://github.com/headroomlabs-ai/headroom): Compress tool outputs, logs, files, and RAG chunks before reaching the LLM — 60-95% fewer tokens, same answers.
@@ -258,6 +260,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [DeerFlow](https://github.com/bytedance/deer-flow): ByteDance's open-source long-horizon SuperAgent harness that researches, codes, and creates with sandboxes, memory, tools, and multi-agent coordination.
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit): Frontend stack for agents and generative UI with React, Angular, and mobile support. Makers of the AG-UI Protocol for agent-user interaction.
 - [Aegra](https://github.com/aegra/aegra): Open-source self-hosted AI agent backend built with FastAPI and PostgreSQL, a zero-lock-in alternative to managed agent deployment platforms.
+- [CowAgent](https://github.com/zhayujie/CowAgent): Open-source super AI assistant and agent harness that plans tasks, runs tools and skills, and self-evolves with memory and knowledge (formerly chatgpt-on-wechat).
 
 ## DataOps
 
@@ -434,6 +437,7 @@ A curated technology stack and toolchain for platform engineering.
 - [Goose](https://github.com/aaif-goose/goose): Open-source extensible AI agent that installs, executes, edits, and tests code with any LLM, going beyond code suggestions into full task execution.
 - [Qwen Code](https://github.com/QwenLM/qwen-code): Open-source AI coding agent that runs in the terminal with multi-file editing, task planning, and MCP server integration.
 - [Open SWE](https://github.com/langchain-ai/open-swe): Open-source asynchronous coding agent from LangChain for automated software engineering with parallel task execution.
+- [OpenCode](https://github.com/anomalyco/opencode): The open source coding agent — fast, lightweight CLI coding agent with low token overhead and broad LLM support.
 
 ### Developer Environments
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -189,11 +189,13 @@
 - [Weaviate](https://github.com/weaviate/weaviate)：开源向量数据库，结合向量搜索、结构化过滤和生成式 AI 集成能力。
 - [pgvector](https://github.com/pgvector/pgvector)：PostgreSQL 的开源向量相似度搜索扩展，广泛用于 RAG 和 AI 嵌入存储。
 - [LanceDB](https://github.com/lancedb/lancedb)：面向开发者的嵌入式向量数据库，支持多模态 AI 搜索，采用无服务器架构和零拷贝检索。
+- [zvec](https://github.com/alibaba/zvec)：阿里巴巴开源的轻量级、极速进程内向量数据库，用于嵌入式 AI 搜索和检索，Apache-2.0 许可。
 - [txtai](https://github.com/neuml/txtai)：一体化 AI 框架，支持语义搜索、LLM 编排和语言模型工作流，内置嵌入和流水线能力。
 - [Feast](https://github.com/feast-dev/feast)：面向 AI/ML 的开源特征存储，可在模型训练和在线推理中一致地提供特征数据。
 - [Instructor](https://github.com/567-labs/instructor)：面向 LLM 的结构化输出工具，基于 Pydantic 校验，支持自动重试和跨供应商统一 API。
 - [pgai](https://github.com/timescale/pgai)：面向 PostgreSQL 的开源 AI 工具套件，支持在 PostgreSQL 上直接构建 RAG、语义搜索和 AI 应用。
 - [Browser Use](https://github.com/browser-use/browser-use)：开源 Web 自动化工具包，让 AI Agent 能够浏览网页、提取数据并大规模执行在线自动化任务。
+- [Agent-Reach](https://github.com/Panniantong/Agent-Reach)：为 AI Agent 装上观察互联网的眼睛——通过一条 CLI 零 API 费用阅读和搜索 Twitter、Reddit、YouTube、GitHub、Bilibili 等平台。
 - [Steel Browser](https://github.com/steel-dev/steel-browser)：开源无头浏览器沙箱，为 AI Agent 和应用提供生产就绪的 Web 自动化基础设施。
 - [E2B](https://github.com/e2b-dev/E2B)：开源安全云沙箱，用于运行 AI Agent 代码，提供隔离环境、文件系统访问和真实工具执行能力。
 - [headroom](https://github.com/headroomlabs-ai/headroom)：在 LLM 调用前压缩工具输出、日志、文件和 RAG 片段——节省 60-95% Token，效果不变。
@@ -258,6 +260,7 @@
 - [DeerFlow](https://github.com/bytedance/deer-flow)：字节跳动开源的长周期 SuperAgent 框架，支持沙箱、记忆、工具和多 Agent 协调，可进行研究、编码和创作。
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit)：面向 Agent 和生成式 UI 的前端技术栈，支持 React、Angular 和移动端。AG-UI Protocol 的创建者，用于 Agent 与用户的交互。
 - [Aegra](https://github.com/aegra/aegra)：开源自托管 AI Agent 后端，基于 FastAPI 和 PostgreSQL 构建，是托管式 Agent 部署平台的零锁定替代方案。
+- [CowAgent](https://github.com/zhayujie/CowAgent)：开源超级 AI 助手与 Agent 驾驭框架，支持任务规划、工具与技能执行，通过记忆和知识实现自我进化（原 chatgpt-on-wechat）。
 
 ## DataOps
 
@@ -434,6 +437,7 @@
 - [Goose](https://github.com/aaif-goose/goose)：开源可扩展 AI Agent，可用任意 LLM 安装、执行、编辑和测试代码，超越代码建议进入完整任务执行。
 - [Qwen Code](https://github.com/QwenLM/qwen-code)：开源终端 AI 编码 Agent，支持多文件编辑、任务规划和 MCP Server 集成。
 - [Open SWE](https://github.com/langchain-ai/open-swe)：LangChain 出品的开源异步编码 Agent，支持并行任务执行的自动化软件工程。
+- [OpenCode](https://github.com/anomalyco/opencode)：开源编码 Agent——快速、轻量的 CLI 编码工具，以低 Token 开销和广泛 LLM 支持著称。
 
 ### Developer Environments 开发环境
 


### PR DESCRIPTION
## Summary

Add 4 new high-quality entries across AI Coding Tools, AI Infrastructure, and Agentic Workflow categories. All projects are well-adopted open-source tools with strong community traction.

## Projects Added

| Project | Stars | Category | License |
|---------|-------|----------|---------|
| **OpenCode** | 185,063 | AI Coding Tools | MIT |
| **Agent-Reach** | 55,308 | AI Infrastructure | MIT |
| **zvec** | 14,809 | AI Infrastructure | Apache-2.0 |
| **CowAgent** | 45,945 | Agentic Workflow | MIT |

### OpenCode
The open source coding agent — fast, lightweight CLI coding agent with low token overhead and broad LLM support. Trending on HN (339 pts) for its 5x lower token overhead compared to Claude Code. TypeScript, MIT.

### Agent-Reach
Give your AI agent eyes to see the entire internet — read and search Twitter, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu, and more via one CLI with zero API fees. Python, MIT, 55K stars.

### zvec
Lightweight, lightning-fast in-process vector database from Alibaba for embedded AI search and retrieval. C++, Apache-2.0, 14.8K stars. Complements existing LanceDB entry with a different architecture approach.

### CowAgent
Open-source super AI assistant and agent harness that plans tasks, runs tools and skills, and self-evolves with memory and knowledge (formerly chatgpt-on-wechat). Python, MIT, 46K stars, one of the most popular agent frameworks in the Chinese AI ecosystem.

## Validation

- ✅ Markdown structural checks (no duplicates, valid internal links)
- ✅ Both README.md and README.zh-CN.md updated consistently
- ✅ Rebased onto latest origin/main (c87f91b)
- ✅ Remote HEAD matches local HEAD
- ✅ Diff scope: only README.md and README.zh-CN.md (8 insertions)
- ✅ No duplicate URLs or entry names

## Risk

Low. All entries are from active, well-documented open-source projects with large communities. OpenCode is MIT-licensed and trending; Agent-Reach and CowAgent are established projects with 45K-55K stars; zvec is from Alibaba with Apache-2.0 license.

## Auto-merge

Auto-merging per sprint mode: diff is clean, validation passes, branch is fresh, no failing checks.