### PR TITLE
docs: add Composio, PageIndex, and ToolHive to AI ops catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [MindsDB](https://github.com/mindsdb/mindshub): AI database platform that connects models to data sources, enabling AI-powered queries, automations, and agent workflows.
 - [Open Connector](https://github.com/oomol-lab/open-connector): Open-source auth gateway connecting 1000+ SaaS providers to AI agents through SDK, CLI, MCP, HTTP, and OpenAPI.
 - [MCP Use](https://github.com/mcp-use/mcp-use): Fullstack MCP framework for building MCP applications, servers, and agent tools for ChatGPT, Claude, and other AI assistants.
+- [Composio](https://github.com/ComposioHQ/composio): Agent tool-integration platform with managed toolkits, tool search, authentication, context management, and sandboxed execution.
+- [PageIndex](https://github.com/VectifyAI/PageIndex): Vectorless, reasoning-based document indexing system for retrieval-augmented generation over long documents.
 
 ## LLM Knowledge
 
@@ -385,6 +387,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [ORT](https://github.com/oss-review-toolkit/ort): Toolkit for automating open-source compliance checks across dependencies, licenses, copyrights, vulnerabilities, and SBOM generation.
 - [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli): Command-line tool for validating, converting, merging, and diffing CycloneDX SBOMs and related formats.
 - [Dependency-Track](https://github.com/DependencyTrack/dependency-track): Component analysis platform for tracking SBOMs, vulnerabilities, licenses, and software supply-chain risk.
+- [ToolHive](https://github.com/stacklok/toolhive): Enterprise platform for securely running and managing MCP servers with isolation, lifecycle controls, and operational governance.
 - [Tracecat](https://github.com/TracecatHQ/tracecat): Open-source security automation platform for teams and AI agents with event-driven orchestration, monitoring, and low-code workflows.
 - [OneCLI](https://github.com/onecli/onecli): Open-source credential gateway with built-in vault for giving AI agents access to services without exposing secrets.
 - [OpenAnt](https://github.com/knostic/OpenAnt): Open-source LLM-based vulnerability discovery tool for proactively finding verified security flaws in AI systems.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,6 +217,8 @@
 - [MindsDB](https://github.com/mindsdb/mindshub)：AI 数据库平台，将模型连接到数据源，支持 AI 驱动的查询、自动化和 Agent 工作流。
 - [Open Connector](https://github.com/oomol-lab/open-connector)：开源认证网关，通过 SDK、CLI、MCP、HTTP 和 OpenAPI 将 1000+ SaaS 提供商连接到 AI Agent。
 - [MCP Use](https://github.com/mcp-use/mcp-use)：全栈 MCP 框架，用于构建面向 ChatGPT、Claude 等 AI 助手的 MCP 应用、Server 和 Agent 工具。
+- [Composio](https://github.com/ComposioHQ/composio)：Agent 工具集成平台，提供托管工具包、工具搜索、身份认证、上下文管理和沙箱执行能力。
+- [PageIndex](https://github.com/VectifyAI/PageIndex)：基于向量无关、推理驱动的文档索引系统，用于对长文档执行检索增强生成。
 
 ## LLM 知识库
 
@@ -385,6 +387,7 @@
 - [ORT](https://github.com/oss-review-toolkit/ort)：用于自动化开源合规检查的工具集，覆盖依赖、License、版权、漏洞和 SBOM 生成。
 - [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli)：用于校验、转换、合并和比对 CycloneDX SBOM 及相关格式的命令行工具。
 - [Dependency-Track](https://github.com/DependencyTrack/dependency-track)：组件分析平台，用于跟踪 SBOM、漏洞、License 和软件供应链风险。
+- [ToolHive](https://github.com/stacklok/toolhive)：企业级 MCP Server 安全运行与管理平台，提供隔离、生命周期控制和运维治理能力。
 - [Tracecat](https://github.com/TracecatHQ/tracecat)：面向团队和 AI Agent 的开源安全自动化平台，支持事件驱动编排、监控和低代码工作流。
 - [OneCLI](https://github.com/onecli/onecli)：开源凭据网关，内置密钥保险库，让 AI Agent 无需暴露密钥即可安全访问服务。
 - [OpenAnt](https://github.com/knostic/OpenAnt)：基于 LLM 的开源漏洞发现工具，可主动发现 AI 系统中经过验证的安全漏洞。


### PR DESCRIPTION
## Summary
- Add Composio and PageIndex to AI Infrastructure for agent tool integration and reasoning-based document indexing.
- Add ToolHive to Security and Supply Chain for MCP server operations and governance.
- Keep English and Simplified Chinese README entries aligned.

## Projects added
- Composio
- PageIndex
- ToolHive

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- Bilingual candidate parity passed.
- `git diff --check` passed.
- Changed files limited to `README.md` and `README.zh-CN.md`.
- Branch rebased onto latest `origin/main`; freshness verified.

## Risk
- Documentation-only change; project descriptions may evolve upstream.

## Auto-merge intent
- Leave open for maintainer review; do not auto-merge.