### PR TITLE
docs: add agent observability tools to AI Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [AgentField](https://github.com/Agent-Field/agentfield): Control plane for building, running, and scaling observable, auditable, identity-aware AI agents as APIs and microservices.
 - [Prompty](https://github.com/microsoft/prompty): Markdown-based prompt format and tooling for creating, managing, debugging, and evaluating portable LLM prompts.
 - [Archestra](https://github.com/archestra-ai/archestra): Enterprise AI platform with guardrails, MCP registry, gateway, and orchestration for governed agent operations.
+- [Databuff](https://github.com/databufflabs/databuff): AI-native OpenTelemetry APM with multi-agent root-cause analysis across traces, metrics, and service topology.
+- [RocketplaneIO](https://github.com/olemeyer/rocketplaneIO): Self-hosted AI SRE for Kubernetes with zero-instrumentation eBPF observability and guardrailed, self-verifying remediation.
+- [AgentProvenance](https://github.com/ByteYellow/AgentProvenance): Security-oriented observability for sandboxed AI agents, combining model intent, application context, and runtime telemetry into verifiable evidence graphs.
+- [AgentCanvas](https://github.com/vstorm-co/agentcanvas): Interactive HTML diagrams for visualizing Pydantic AI agent workflows from Logfire traces, including tools, nested agents, tokens, and cost.
 
 ## AI Serving and Inference Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,6 +126,10 @@
 - [AgentField](https://github.com/Agent-Field/agentfield)：用于构建、运行和扩展 AI Agent 的控制平面，让 Agent 以可观测、可审计、具备身份感知的 API 和微服务方式运行。
 - [Prompty](https://github.com/microsoft/prompty)：基于 Markdown 的 Prompt 格式与工具链，用于创建、管理、调试和评估可移植的 LLM Prompt。
 - [Archestra](https://github.com/archestra-ai/archestra)：企业级 AI 平台，提供护栏、MCP 注册中心、网关和编排能力，用于治理 Agent 运维。
+- [Databuff](https://github.com/databufflabs/databuff)：AI 原生 OpenTelemetry APM，支持跨链路、指标和服务拓扑的多 Agent 根因分析。
+- [RocketplaneIO](https://github.com/olemeyer/rocketplaneIO)：自托管 AI SRE，提供无需插桩的 eBPF 可观测性，以及带护栏、可自验证的 Kubernetes 故障修复能力。
+- [AgentProvenance](https://github.com/ByteYellow/AgentProvenance)：面向沙箱 AI Agent 的安全观测工具，将模型意图、应用上下文和运行时遥测汇聚为可验证的证据图谱。
+- [AgentCanvas](https://github.com/vstorm-co/agentcanvas)：根据 Logfire trace 生成交互式 HTML 图，展示 Pydantic AI Agent 工作流中的工具、嵌套 Agent、Token 和成本。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 


### PR DESCRIPTION
## Summary
Add four production-oriented AI/agent observability entries to both bilingual READMEs.

## Projects added
- Databuff
- RocketplaneIO
- AgentProvenance
- AgentCanvas

## Validation
- Markdown structural checks passed.
- Bilingual GitHub project URL parity passed: 383 EN / 383 zh-CN.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Self-review: diff is limited to the two expected README files and entries are semantically aligned.

## Risk
Documentation-only; low runtime risk. Project maturity and descriptions should be revisited during periodic curation.

## Auto-merge intent
Auto-merge after self-review and green or absent checks.