### PR TITLE
docs: add Onyx and LangBot to AI operations catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [MCP Use](https://github.com/mcp-use/mcp-use): Fullstack MCP framework for building MCP applications, servers, and agent tools for ChatGPT, Claude, and other AI assistants.
 - [Composio](https://github.com/ComposioHQ/composio): Agent tool-integration platform with managed toolkits, tool search, authentication, context management, and sandboxed execution.
 - [PageIndex](https://github.com/VectifyAI/PageIndex): Vectorless, reasoning-based document indexing system for retrieval-augmented generation over long documents.
+- [Onyx](https://github.com/onyx-dot-app/onyx): Open-source AI platform for enterprise search and AI chat, combining retrieval, connectors, agent workflows, and self-hosted deployment.
 
 ## LLM Knowledge
 
@@ -278,6 +279,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Activepieces](https://github.com/activepieces/activepieces): Open-source AI automation platform with ~400 built-in MCP servers for no-code AI agent workflows, automation, and MCP integrations.
 - [NanoBot](https://github.com/HKUDS/nanobot): Lightweight, open-source AI agent for tools, chats, and automated workflows with extensible plugin architecture.
 - [Harbor Framework](https://github.com/harbor-framework/harbor): Framework for evaluating and improving agents and language models across reproducible environments and parallel experiments.
+- [LangBot](https://github.com/langbot-app/LangBot): Production-oriented multi-platform bot platform with agent workflows, knowledge bases, plugins, and integrations for chat systems.
 
 ## DataOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -227,7 +227,8 @@
 - [Open Connector](https://github.com/oomol-lab/open-connector)：开源认证网关，通过 SDK、CLI、MCP、HTTP 和 OpenAPI 将 1000+ SaaS 提供商连接到 AI Agent。
 - [MCP Use](https://github.com/mcp-use/mcp-use)：全栈 MCP 框架，用于构建面向 ChatGPT、Claude 等 AI 助手的 MCP 应用、Server 和 Agent 工具。
 - [Composio](https://github.com/ComposioHQ/composio)：Agent 工具集成平台，提供托管工具包、工具搜索、身份认证、上下文管理和沙箱执行能力。
-- [PageIndex](https://github.com/VectifyAI/PageIndex)：基于向量无关、推理驱动的文档索引系统，用于对长文档执行检索增强生成。
+- [PageIndex](https://github.com/VectifyAI/PageIndex)：与向量无关、基于推理的文档索引系统，用于对长文档执行检索增强生成。
+- [Onyx](https://github.com/onyx-dot-app/onyx)：开源 AI 平台，面向企业搜索和 AI Chat，整合检索、数据连接器、Agent 工作流与自托管部署能力。
 
 ## LLM 知识库
 
@@ -277,7 +278,8 @@
 - [CowAgent](https://github.com/zhayujie/CowAgent)：开源超级 AI 助手与 Agent 驾驭框架，支持任务规划、工具与技能执行，通过记忆和知识实现自我进化（原 chatgpt-on-wechat）。
 - [Activepieces](https://github.com/activepieces/activepieces)：开源 AI 自动化平台，内置约 400 个 MCP Server，支持无代码 AI Agent 工作流、自动化和 MCP 集成。
 - [NanoBot](https://github.com/HKUDS/nanobot)：轻量级开源 AI Agent，适用于工具调用、对话和自动化工作流，支持可扩展插件架构。
-- [Harbor Framework](https://github.com/harbor-framework/harbor)：用于在可复现环境和并行实验中评估与改进 Agent 及语言模型的框架。
+- [Harbor Framework](https://github.com/harbor-framework/harbor)：用于在可复现环境和并行实验中评估与改进 Agent 和语言模型的框架。
+- [LangBot](https://github.com/langbot-app/LangBot)：面向生产的多平台机器人平台，支持 Agent 工作流、知识库、插件，以及与多种聊天系统集成。
 
 ## DataOps
 


### PR DESCRIPTION
## Summary
- Add two high-signal AI operations projects to the bilingual catalog.
- Keep English and Simplified Chinese entries aligned.

## Projects added
- Onyx — enterprise search and AI chat platform with retrieval, connectors, agent workflows, and self-hosting.
- LangBot — production-oriented multi-platform bot platform with agent workflows, knowledge bases, plugins, and chat integrations.

## Validation
- Markdown structural checks passed.
- Internal-link and duplicate URL/name checks passed.
- Bilingual project URL parity passed (386 GitHub project URLs).
- `git diff --check` passed.
- Rebased onto latest `origin/main`; remote branch verified to match local HEAD.
- Self-review: docs-only diff limited to `README.md` and `README.zh-CN.md`; entries are category-appropriate and semantically aligned.

## Risk
Low: documentation-only changes; no runtime or dependency impact. Project descriptions should be revisited if upstream scope changes.

## Auto-merge intent
Merge with squash after PR checks are green or absent; no checks will be bypassed.