### PR TITLE
docs: add Kubernetes AI operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [RocketplaneIO](https://github.com/olemeyer/rocketplaneIO): Self-hosted AI SRE for Kubernetes with zero-instrumentation eBPF observability and guardrailed, self-verifying remediation.
 - [AgentProvenance](https://github.com/ByteYellow/AgentProvenance): Security-oriented observability for sandboxed AI agents, combining model intent, application context, and runtime telemetry into verifiable evidence graphs.
 - [AgentCanvas](https://github.com/vstorm-co/agentcanvas): Interactive HTML diagrams for visualizing Pydantic AI agent workflows from Logfire traces, including tools, nested agents, tokens, and cost.
+- [Kaito](https://github.com/kaito-project/kaito): Kubernetes AI Toolchain Operator for simplifying model deployment and AI workload management on Kubernetes.
+- [OME](https://github.com/ome-projects/ome): Kubernetes operator for LLM serving, GPU scheduling, and model lifecycle management across SGLang, vLLM, TensorRT-LLM, and Triton.
+- [AURA](https://github.com/mezmo/aura): Production-oriented harness for safe AI SRE agents, with guardrails, state management, authentication, streaming, and operational tool integrations.
+- [ongrid](https://github.com/ongridio/ongrid): Ops AI agent that investigates infrastructure root causes and performs guarded remediation through common team-chat interfaces.
 
 ## AI Serving and Inference Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,6 +130,10 @@
 - [RocketplaneIO](https://github.com/olemeyer/rocketplaneIO)：自托管 AI SRE，提供无需插桩的 eBPF 可观测性，以及带护栏、可自验证的 Kubernetes 故障修复能力。
 - [AgentProvenance](https://github.com/ByteYellow/AgentProvenance)：面向沙箱 AI Agent 的安全观测工具，将模型意图、应用上下文和运行时遥测汇聚为可验证的证据图谱。
 - [AgentCanvas](https://github.com/vstorm-co/agentcanvas)：根据 Logfire trace 生成交互式 HTML 图，展示 Pydantic AI Agent 工作流中的工具、嵌套 Agent、Token 和成本。
+- [Kaito](https://github.com/kaito-project/kaito)：Kubernetes AI 工具链 Operator，用于简化 Kubernetes 上的模型部署和 AI 工作负载管理。
+- [OME](https://github.com/ome-projects/ome)：Kubernetes Operator，用于管理 LLM 服务、GPU 调度和模型生命周期，支持 SGLang、vLLM、TensorRT-LLM 与 Triton。
+- [AURA](https://github.com/mezmo/aura)：面向生产的安全 AI SRE Agent 驾驭框架，提供护栏、状态管理、身份认证、流式执行和运维工具集成。
+- [ongrid](https://github.com/ongridio/ongrid)：运维 AI Agent，可通过常见团队聊天界面调查基础设施根因并执行带护栏的修复。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 


### PR DESCRIPTION
## Summary
Add a small bilingual batch of production-oriented AI operations entries to the LLM and Agent Observability catalog.

## Projects added
- Kaito — Kubernetes AI Toolchain Operator.
- OME — Kubernetes operator for LLM serving, GPU scheduling, and model lifecycle management.
- AURA — production-oriented harness for guarded AI SRE agents.
- ongrid — operations AI agent for root-cause investigation and guarded remediation.

## Validation
- Markdown structural checks passed.
- Internal links and duplicate URL/name checks passed.
- English/Chinese GitHub project URL parity passed (390/390).
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Scope limited to `README.md` and `README.zh-CN.md`.

## Risk
Documentation-only change. Project maturity and operational claims should be revisited as these fast-moving AI operations projects evolve.

## Auto-merge intent
Auto-merge after self-review if the diff remains limited to the expected README files and checks are green or absent.
