### PR TITLE
docs: add AI agent training and platform tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [text-generation-webui](https://github.com/oobabooga/textgen): Open-source desktop app for running LLMs locally with text, vision, tool-calling, and OpenAI/Anthropic-compatible API support.
 - [DS4](https://github.com/antirez/ds4): High-performance local inference engine for DeepSeek 4 Flash and PRO, optimized for Metal, CUDA, and ROCm platforms.
 - [RouteLLM](https://github.com/lm-sys/RouteLLM): Framework for serving and evaluating LLM routers that direct requests to cheaper models while preserving response quality.
+- [Rig](https://github.com/0xPlaygrounds/rig): Rust framework for building modular, scalable LLM applications with composable components and provider integrations.
+- [Agent Lightning](https://github.com/microsoft/agent-lightning): Framework for training and optimizing AI agents by connecting agent execution with reinforcement learning and other training methods.
 
 ## AIOps
 
@@ -187,6 +189,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [AiSOC](https://github.com/beenuar/AiSOC): Open-source AI-powered Security Operations Center for alert fusion, agent-assisted triage, purple-team drills, and MITRE ATT&CK investigation workflows.
 - [APO](https://github.com/CloudDetail/apo): AI-powered observability platform combining OpenTelemetry, eBPF, and LLM agentic workflows for automated root-cause analysis and intelligent troubleshooting.
 - [HolmesGPT](https://github.com/HolmesGPT/holmesgpt): CNCF Sandbox SRE agent that investigates alerts and operational incidents using cluster context, runbooks, and observability data.
+- [Metaflow](https://github.com/Netflix/metaflow): Human-centric framework for developing, versioning, scaling, and deploying production AI/ML systems from prototypes to reliable workflows.
 
 ## AI Infrastructure
 
@@ -234,6 +237,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Composio](https://github.com/ComposioHQ/composio): Agent tool-integration platform with managed toolkits, tool search, authentication, context management, and sandboxed execution.
 - [PageIndex](https://github.com/VectifyAI/PageIndex): Vectorless, reasoning-based document indexing system for retrieval-augmented generation over long documents.
 - [Onyx](https://github.com/onyx-dot-app/onyx): Open-source AI platform for enterprise search and AI chat, combining retrieval, connectors, agent workflows, and self-hosted deployment.
+- [Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack): Production-oriented templates for shipping AI agents with built-in CI/CD, evaluation, observability, and Google Cloud deployment paths.
 
 ## LLM Knowledge
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,6 +175,8 @@
 - [text-generation-webui](https://github.com/oobabooga/textgen)：开源桌面应用，可在本地运行 LLM，支持文本、视觉、工具调用和 OpenAI/Anthropic 兼容 API。
 - [DS4](https://github.com/antirez/ds4)：高性能本地推理引擎，支持 DeepSeek 4 Flash 和 PRO 模型，针对 Metal、CUDA 和 ROCm 平台优化。
 - [RouteLLM](https://github.com/lm-sys/RouteLLM)：用于部署和评估 LLM 路由器的框架，可在保持响应质量的同时将请求转发给更低成本的模型。
+- [Rig](https://github.com/0xPlaygrounds/rig)：用于构建模块化、可扩展 LLM 应用的 Rust 框架，提供可组合组件和多供应商集成。
+- [Agent Lightning](https://github.com/microsoft/agent-lightning)：用于训练和优化 AI Agent 的框架，可将 Agent 执行过程连接到强化学习及其他训练方法。
 
 ## AIOps 智能运维
 
@@ -187,6 +189,7 @@
 - [AiSOC](https://github.com/beenuar/AiSOC)：开源 AI 驱动安全运营中心，支持告警融合、Agent 辅助分类、紫队演练和 MITRE ATT&CK 调查工作流。
 - [APO](https://github.com/CloudDetail/apo)：AI 驱动的可观测平台，融合 OpenTelemetry、eBPF 和 LLM Agent 工作流，实现自动化根因分析和智能排障。
 - [HolmesGPT](https://github.com/HolmesGPT/holmesgpt)：CNCF Sandbox SRE Agent，结合集群上下文、Runbook 和可观测数据调查告警与运维事件。
+- [Metaflow](https://github.com/Netflix/metaflow)：面向人的 AI/ML 系统开发框架，支持从原型到生产工作流的开发、版本管理、扩展和部署。
 
 ## AI 基础设施
 
@@ -234,6 +237,7 @@
 - [Composio](https://github.com/ComposioHQ/composio)：Agent 工具集成平台，提供托管工具包、工具搜索、身份认证、上下文管理和沙箱执行能力。
 - [PageIndex](https://github.com/VectifyAI/PageIndex)：与向量无关、基于推理的文档索引系统，用于对长文档执行检索增强生成。
 - [Onyx](https://github.com/onyx-dot-app/onyx)：开源 AI 平台，面向企业搜索和 AI Chat，整合检索、数据连接器、Agent 工作流与自托管部署能力。
+- [Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack)：面向生产的 AI Agent 模板，内置 CI/CD、评估和可观测性，并提供 Google Cloud 部署路径。
 
 ## LLM 知识库
 


### PR DESCRIPTION
## Summary
Add four production-oriented AI/X-Ops projects to both README language variants.

## Projects added
- Rig — modular Rust framework for scalable LLM applications.
- Agent Lightning — AI agent training and optimization framework.
- Metaflow — production AI/ML workflow development and deployment framework.
- Agent Starter Pack — production-oriented AI agent templates with CI/CD, evaluation, and observability.

## Validation
- Markdown internal-link and duplicate URL/name checks passed.
- English/Chinese URL parity check passed for all four projects.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Self-review: changed files are limited to `README.md` and `README.zh-CN.md`; descriptions are concise and semantically aligned.

## Risk
Documentation-only change. Main risk is future project status or positioning drift; no runtime behavior is affected.

## Auto-merge intent
Please review; do not auto-merge from this request.