### PR TITLE
docs: add AI agent security operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,10 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard): Full-stack AI red teaming platform for scanning AI infrastructure, agents, skills, MCP servers, and LLM jailbreak vulnerabilities.
 - [AgentShield](https://github.com/affaan-m/agentshield): AI agent security scanner for detecting vulnerabilities in agent configurations, MCP servers, and tool permissions via CLI or GitHub Action.
 - [Adrian](https://github.com/secureagentics/Adrian): Open-source runtime AI agent security tool that monitors and controls AI agents in real time, catching malicious tool use, prompt injection, and policy drift before the agent acts.
+- [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Toolkit for policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous AI agents.
+- [SkillSpector](https://github.com/NVIDIA/SkillSpector): Security scanner for AI agent skills that detects vulnerabilities, malicious patterns, and other security risks.
+- [Agent Scan](https://github.com/snyk/agent-scan): Security scanner for AI agents, MCP servers, and agent skills.
+- [Agent Safehouse](https://github.com/eugene1g/agent-safehouse): Sandbox for local AI agents that limits filesystem access to only the paths they need.
 - [AgentDojo](https://github.com/ethz-spylab/agentdojo): Dynamic environment for evaluating prompt-injection attacks and defenses in tool-using LLM agents.
 
 ## Platform Engineering

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -425,6 +425,10 @@
 - [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard)：全栈 AI 红队平台，用于扫描 AI 基础设施、Agent、技能、MCP Server 和 LLM 越狱漏洞。
 - [AgentShield](https://github.com/affaan-m/agentshield)：AI Agent 安全扫描器，通过 CLI 或 GitHub Action 检测 Agent 配置、MCP Server 和工具权限中的漏洞。
 - [Adrian](https://github.com/secureagentics/Adrian)：开源 AI Agent 运行时安全工具，实时监控和控制 AI Agent，在 Agent 执行动作前拦截恶意工具调用、Prompt 注入和策略偏移。
+- [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)：用于自主 AI Agent 的策略执行、零信任身份、执行沙箱和可靠性工程工具包。
+- [SkillSpector](https://github.com/NVIDIA/SkillSpector)：AI Agent Skill 安全扫描器，用于检测漏洞、恶意模式和其他安全风险。
+- [Agent Scan](https://github.com/snyk/agent-scan)：面向 AI Agent、MCP Server 和 Agent Skill 的安全扫描器。
+- [Agent Safehouse](https://github.com/eugene1g/agent-safehouse)：本地 AI Agent 沙箱，只允许 Agent 访问所需的文件系统路径。
 - [AgentDojo](https://github.com/ethz-spylab/agentdojo)：用于评估工具调用型 LLM Agent 中 Prompt 注入攻击与防御的动态环境。
 
 ## Platform Engineering 平台工程


### PR DESCRIPTION
## Summary
- Add four production-oriented AI agent security operations projects to both README language variants.
- Keep the additions under Security and Supply Chain and retain GitHub-first links.

## Projects added
- Agent Governance Toolkit
- SkillSpector
- Agent Scan
- Agent Safehouse

## Validation
- Markdown internal-link, duplicate URL, and duplicate entry-name checks passed.
- `git diff --check` passed.
- Changed files are limited to `README.md` and `README.zh-CN.md`.
- Rebasing onto latest `origin/main` completed; `origin/main` is an ancestor of the branch.
- Remote branch SHA verified against local HEAD: `e947d99c9d853410496207a5a8fa32693a91ed93`.

## Risk
- Documentation-only change; the main risk is future project classification or maintenance drift.
- Candidate repository metadata was checked with GitHub API; all four repositories are currently active and non-archived.

## Auto-merge intent
- Requesting review first. Do not auto-merge without the required self-review and green or absent checks.