### PR TITLE
docs: add agent observability and runtime security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [ongrid](https://github.com/ongridio/ongrid): Ops AI agent that investigates infrastructure root causes and performs guarded remediation through common team-chat interfaces.
 - [Axon](https://github.com/langchain-tracer/Axon): OpenTelemetry-native LLM observability CLI for viewing LLM and agent traces in real time.
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval): Open-source RAG evaluation toolkit for measuring retrieval and answer quality without requiring golden answers.
+- [Observal](https://github.com/Observal/Observal): Local registry and analytics platform for governing and understanding AI agents, MCP servers, and reusable agent skills.
+- [Agent Prism](https://github.com/evilmartians/agent-prism): React components for visualizing AI agent traces and making multi-step agent execution easier to inspect.
+- [Dash0 Agent Skills](https://github.com/dash0hq/agent-skills): OpenTelemetry skills and reference material for AI coding assistants, covering instrumentation patterns and telemetry quality.
 
 ## AI Serving and Inference Operations
 
@@ -454,6 +457,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Security scanner for agentic workflows that visualizes tools and MCP servers and maps discovered vulnerabilities to security frameworks.
 - [deepsec](https://github.com/vercel-labs/deepsec): Agent-powered security harness for scanning large codebases, investigating hard-to-find vulnerabilities, and exporting findings for review.
 - [Agent Threat Rules](https://github.com/Agent-Threat-Rule/agent-threat-rules): Open detection-rule standard for AI agent security threats, covering prompt injection, MCP risks, tool abuse, and related behaviors.
+- [Aegis](https://github.com/Justin0504/Aegis): Runtime policy enforcement for AI agents with cryptographic audit trails, human approval gates, and an emergency kill switch.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -150,6 +150,9 @@
 - [ongrid](https://github.com/ongridio/ongrid)：运维 AI Agent，可通过常见团队聊天界面调查基础设施根因并执行带护栏的修复。
 - [Axon](https://github.com/langchain-tracer/Axon)：基于 OpenTelemetry 的 LLM 可观测性 CLI，可实时查看 LLM 和 Agent 链路。
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval)：开源 RAG 评估工具包，无需预先准备标准答案即可衡量检索和回答质量。
+- [Observal](https://github.com/Observal/Observal)：本地优先的注册与分析平台，用于治理和理解 AI Agent、MCP Server 及可复用 Agent Skill。
+- [Agent Prism](https://github.com/evilmartians/agent-prism)：用于可视化 AI Agent trace 的 React 组件，帮助检查多步骤 Agent 执行过程。
+- [Dash0 Agent Skills](https://github.com/dash0hq/agent-skills)：面向 AI 编码助手的 OpenTelemetry Skill 与参考资料，涵盖插桩模式和遥测质量指南。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 
@@ -454,6 +457,7 @@
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar)：面向 Agent 工作流的安全扫描器，可可视化工具与 MCP Server，并将发现的漏洞映射到安全框架。
 - [deepsec](https://github.com/vercel-labs/deepsec)：基于 Agent 的代码安全扫描工具，用于检查大型代码库中的隐蔽漏洞，并导出结果供审查。
 - [Agent Threat Rules](https://github.com/Agent-Threat-Rule/agent-threat-rules)：面向 AI Agent 安全威胁的开源检测规则标准，覆盖 Prompt 注入、MCP 风险、工具滥用等行为。
+- [Aegis](https://github.com/Justin0504/Aegis)：AI Agent 运行时策略执行工具，提供加密审计轨迹、人机审批门禁和紧急停止开关。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
- Add four production-oriented AI operations projects to the bilingual catalog.
- Cover agent registry/analytics, agent trace visualization, OpenTelemetry guidance, and runtime policy enforcement.

## Projects added
- Observal
- Agent Prism
- Dash0 Agent Skills
- Aegis

## Validation
- Markdown internal-link, duplicate URL, and duplicate entry-name checks passed.
- English/Chinese new-entry parity check passed (4/4).
- `git diff --check` passed.
- Diff limited to `README.md` and `README.zh-CN.md`.
- Rebased on latest `origin/main`; base is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.

## Risk
- Documentation-only change. Project descriptions are concise and based on current repository metadata; star counts were used only as discovery signals and are not embedded.

## Auto-merge intent
- Requesting automatic squash merge after PR self-review and green/absent checks.