### PR TITLE
docs: add DB-GPT, BoxLite, Chaterm, Tirith, Varlock, CodeBurn, KubeSphere, aikit

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [Rig](https://github.com/0xPlaygrounds/rig): Rust framework for building modular, scalable LLM applications with composable components and provider integrations.
 - [Agent Lightning](https://github.com/microsoft/agent-lightning): Framework for training and optimizing AI agents by connecting agent execution with reinforcement learning and other training methods.
 - [verl](https://github.com/verl-project/verl): Flexible and efficient reinforcement-learning framework for post-training large language models and optimizing reasoning or agent workloads.
+- [aikit](https://github.com/kaito-project/aikit): Kubernetes-native toolkit for fine-tuning, building, and deploying open-source LLMs with buildkit-based image construction and GPU-accelerated inference.
 
 ## AIOps
 
@@ -212,6 +213,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [HolmesGPT](https://github.com/HolmesGPT/holmesgpt): CNCF Sandbox SRE agent that investigates alerts and operational incidents using cluster context, runbooks, and observability data.
 - [K8sGPT](https://github.com/k8sgpt-ai/k8sgpt): Kubernetes troubleshooting tool that applies codified SRE analyzers to diagnose and triage cluster issues with optional AI backends.
 - [Metaflow](https://github.com/Netflix/metaflow): Human-centric framework for developing, versioning, scaling, and deploying production AI/ML systems from prototypes to reliable workflows.
+- [Chaterm](https://github.com/chaterm/Chaterm): Open-source AI terminal for cloud and infrastructure management, enabling natural-language deployment, troubleshooting, and automation across SSH, Kubernetes, and cloud services.
 
 ## AI Infrastructure
 
@@ -261,6 +263,8 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Onyx](https://github.com/onyx-dot-app/onyx): Open-source AI platform for enterprise search and AI chat, combining retrieval, connectors, agent workflows, and self-hosted deployment.
 - [Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack): Production-oriented templates for shipping AI agents with built-in CI/CD, evaluation, observability, and Google Cloud deployment paths.
 - [MCP Inspector](https://github.com/modelcontextprotocol/inspector): Developer tool with a web client and proxy for interactively testing and debugging MCP servers across supported transports.
+- [DB-GPT](https://github.com/eosphoros-ai/DB-GPT): Open-source agentic AI data assistant for building data products, Text-to-SQL, RAG, and multi-agent workflows over private data sources.
+- [BoxLite](https://github.com/boxlite-ai/boxlite): Daemonless micro-VM runtime for AI agents — hardware-isolated, OCI-native execution environments embeddable as a library or deployed as a server.
 
 ## LLM Knowledge
 
@@ -412,6 +416,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Rook](https://github.com/rook/rook): CNCF storage orchestrator for Kubernetes, providing self-managing, self-scaling, and self-healing storage services for Ceph, NFS, and other providers.
 - [MinIO](https://github.com/minio/minio): High-performance, S3-compatible object storage with native Kubernetes support for AI/ML data lakes, analytics, and cloud-native applications.
 - [KubeVirt](https://github.com/kubevirt/kubevirt): Kubernetes-native virtualization platform for running and managing virtual machines alongside containers on Kubernetes.
+- [KubeSphere](https://github.com/kubesphere/kubesphere): Container platform for multi-cloud, datacenter, and edge Kubernetes management with integrated DevOps, observability, service mesh, and multi-tenancy.
 
 ## Security and Supply Chain
 
@@ -458,6 +463,8 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [deepsec](https://github.com/vercel-labs/deepsec): Agent-powered security harness for scanning large codebases, investigating hard-to-find vulnerabilities, and exporting findings for review.
 - [Agent Threat Rules](https://github.com/Agent-Threat-Rule/agent-threat-rules): Open detection-rule standard for AI agent security threats, covering prompt injection, MCP risks, tool abuse, and related behaviors.
 - [Aegis](https://github.com/Justin0504/Aegis): Runtime policy enforcement for AI agents with cryptographic audit trails, human approval gates, and an emergency kill switch.
+- [Tirith](https://github.com/sheeki03/tirith): Terminal security tool for developers and AI agents that intercepts homograph URLs, pipe-to-shell, ANSI injection, obfuscated payloads, and data exfiltration before execution.
+- [Varlock](https://github.com/dmno-dev/varlock): AI-safe environment variable format that separates machine-readable schemas for agents from human-readable secrets, preventing accidental credential exposure in agent configs.
 
 ## Platform Engineering
 
@@ -512,6 +519,7 @@ A curated technology stack and toolchain for platform engineering.
 - [OpenCode](https://github.com/anomalyco/opencode): The open source coding agent — fast, lightweight CLI coding agent with low token overhead and broad LLM support.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli): Google's open-source AI agent that brings Gemini's power into the terminal for coding, file editing, and task automation.
 - [OpenWiki](https://github.com/langchain-ai/openwiki): CLI that writes and maintains agent documentation for codebases, automatically keeping docs in sync as the code evolves.
+- [CodeBurn](https://github.com/getagentseal/codeburn): Free local tool for tracking AI coding token usage and cost across 31 tools and agents, with breakdowns by model, project, and task.
 
 ### Developer Environments
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -198,6 +198,7 @@
 - [Rig](https://github.com/0xPlaygrounds/rig)：用于构建模块化、可扩展 LLM 应用的 Rust 框架，提供可组合组件和多供应商集成。
 - [Agent Lightning](https://github.com/microsoft/agent-lightning)：用于训练和优化 AI Agent 的框架，可将 Agent 执行过程连接到强化学习及其他训练方法。
 - [verl](https://github.com/verl-project/verl)：灵活高效的大语言模型后训练强化学习框架，可用于优化推理和 Agent 工作负载。
+- [aikit](https://github.com/kaito-project/aikit)：Kubernetes 原生工具包，支持基于 buildkit 的镜像构建和 GPU 加速推理，用于微调、构建和部署开源 LLM。
 
 ## AIOps 智能运维
 
@@ -212,6 +213,7 @@
 - [HolmesGPT](https://github.com/HolmesGPT/holmesgpt)：CNCF Sandbox SRE Agent，结合集群上下文、Runbook 和可观测数据调查告警与运维事件。
 - [K8sGPT](https://github.com/k8sgpt-ai/k8sgpt)：Kubernetes 故障排查工具，将编码后的 SRE 分析器用于诊断和分流集群问题，并支持可选的 AI 后端。
 - [Metaflow](https://github.com/Netflix/metaflow)：面向人的 AI/ML 系统开发框架，支持从原型到生产工作流的开发、版本管理、扩展和部署。
+- [Chaterm](https://github.com/chaterm/Chaterm)：开源 AI 终端，面向云和基础设施管理，支持通过自然语言跨 SSH、Kubernetes 和云服务进行部署、排障和自动化。
 
 ## AI 基础设施
 
@@ -261,6 +263,8 @@
 - [Onyx](https://github.com/onyx-dot-app/onyx)：开源 AI 平台，面向企业搜索和 AI Chat，整合检索、数据连接器、Agent 工作流与自托管部署能力。
 - [Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack)：面向生产的 AI Agent 模板，内置 CI/CD、评估和可观测性，并提供 Google Cloud 部署路径。
 - [MCP Inspector](https://github.com/modelcontextprotocol/inspector)：带有 Web 客户端和代理的开发者工具，用于通过多种传输方式交互式测试和调试 MCP Server。
+- [DB-GPT](https://github.com/eosphoros-ai/DB-GPT)：开源 Agentic AI 数据助手，支持构建数据产品、Text-to-SQL、RAG 和基于私有数据源的多 Agent 工作流。
+- [BoxLite](https://github.com/boxlite-ai/boxlite)：无守护进程的 AI Agent 微虚拟机运行时，提供硬件隔离、OCI 原生的执行环境，可作为库嵌入或以服务器模式部署。
 
 ## LLM 知识库
 
@@ -412,6 +416,7 @@
 - [Rook](https://github.com/rook/rook)：CNCF Kubernetes 存储编排器，为 Ceph、NFS 等存储系统提供自管理、自扩容和自修复的存储服务。
 - [MinIO](https://github.com/minio/minio)：高性能 S3 兼容对象存储，原生支持 Kubernetes，适用于 AI/ML 数据湖、分析和云原生应用。
 - [KubeVirt](https://github.com/kubevirt/kubevirt)：Kubernetes 原生虚拟化平台，可在 Kubernetes 上与容器一同运行和管理虚拟机。
+- [KubeSphere](https://github.com/kubesphere/kubesphere)：面向多云、数据中心和边缘 Kubernetes 管理的容器平台，集成 DevOps、可观测性、服务网格和多租户能力。
 
 ## Security and Supply Chain 安全与供应链
 
@@ -458,6 +463,8 @@
 - [deepsec](https://github.com/vercel-labs/deepsec)：基于 Agent 的代码安全扫描工具，用于检查大型代码库中的隐蔽漏洞，并导出结果供审查。
 - [Agent Threat Rules](https://github.com/Agent-Threat-Rule/agent-threat-rules)：面向 AI Agent 安全威胁的开源检测规则标准，覆盖 Prompt 注入、MCP 风险、工具滥用等行为。
 - [Aegis](https://github.com/Justin0504/Aegis)：AI Agent 运行时策略执行工具，提供加密审计轨迹、人机审批门禁和紧急停止开关。
+- [Tirith](https://github.com/sheeki03/tirith)：面向开发者和 AI Agent 的终端安全工具，在执行前拦截同形异义 URL、管道注入、ANSI 注入、混淆载荷和数据泄露。
+- [Varlock](https://github.com/dmno-dev/varlock)：AI 安全的环境变量格式，将面向 Agent 的机器可读 Schema 与面向人类的 Secret 分离，防止 Agent 配置中的凭据意外泄露。
 
 ## Platform Engineering 平台工程
 
@@ -512,6 +519,7 @@
 - [OpenCode](https://github.com/anomalyco/opencode)：开源编码 Agent——快速、轻量的 CLI 编码工具，以低 Token 开销和广泛 LLM 支持著称。
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli)：谷歌开源的 AI Agent，将 Gemini 的强大能力带入终端，用于编码、文件编辑和任务自动化。
 - [OpenWiki](https://github.com/langchain-ai/openwiki)：用于为代码库编写和维护 Agent 文档的 CLI 工具，随代码演进自动保持文档同步。
+- [CodeBurn](https://github.com/getagentseal/codeburn)：免费本地工具，可追踪 31 种 AI 编码工具和 Agent 的 Token 用量与成本，按模型、项目和任务维度拆分。
 
 ### Developer Environments 开发环境
 


### PR DESCRIPTION
## Summary

Add 8 high-quality projects across AI Infrastructure, AI Serving, AIOps, Kubernetes Operations, Security, and AI Coding Tools — strengthening the AI operations coverage of awesome-x-ops.

## Projects added

| Project | Category | Stars | Rationale |
|---------|----------|-------|-----------|
| [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | AI Infrastructure | ~19.5k | Open-source agentic AI data assistant for Text-to-SQL, RAG, and multi-agent workflows over private data |
| [BoxLite](https://github.com/boxlite-ai/boxlite) | AI Infrastructure | ~2.2k | Daemonless micro-VM runtime for AI agents — hardware-isolated, OCI-native execution environments |
| [aikit](https://github.com/kaito-project/aikit) | AI Serving and Inference Operations | ~534 | Kubernetes-native toolkit for fine-tuning, building, and deploying open-source LLMs |
| [Chaterm](https://github.com/chaterm/Chaterm) | AIOps | ~3k | Open-source AI terminal for cloud and infrastructure management with natural-language operations |
| [KubeSphere](https://github.com/kubesphere/kubesphere) | Kubernetes Operations | ~17k | Container platform for multi-cloud Kubernetes management with integrated DevOps, observability, and multi-tenancy |
| [Tirith](https://github.com/sheeki03/tirith) | Security and Supply Chain | ~2.6k | Terminal security tool for AI agents that intercepts homograph URLs, ANSI injection, and data exfiltration |
| [Varlock](https://github.com/dmno-dev/varlock) | Security and Supply Chain | ~3.8k | AI-safe environment variable format separating agent schemas from human secrets |
| [CodeBurn](https://github.com/getagentseal/codeburn) | AI Coding Tools | ~8.8k | Free local tool for tracking AI coding token usage and cost across 31 tools and agents |

## Validation

- ✅ Markdown structural checks: internal links, duplicate URLs, duplicate entry names — all passed
- ✅ Bilingual entries: all 8 projects added to both README.md and README.zh-CN.md with equivalent meaning
- ✅ No duplicates: verified by name, URL, and org/repo against existing entries
- ✅ Diff scope: only README.md and README.zh-CN.md changed
- ✅ Branch based on latest origin/main (rebased, ancestor verified)
- ✅ Remote branch SHA matches local HEAD

## Risk

- Low risk: documentation-only changes, no code or config changes
- All entries are actively maintained, non-archived, with meaningful adoption
- Chaterm license is NOASSERTION (custom), but project is open-source with CNCF Landscape listing

## Auto-merge intent

Self-review completed; will squash merge after confirming checks.