### PR TITLE
docs: add agent observability and gateway tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [OME](https://github.com/ome-projects/ome): Kubernetes operator for LLM serving, GPU scheduling, and model lifecycle management across SGLang, vLLM, TensorRT-LLM, and Triton.
 - [AURA](https://github.com/mezmo/aura): Production-oriented harness for safe AI SRE agents, with guardrails, state management, authentication, streaming, and operational tool integrations.
 - [ongrid](https://github.com/ongridio/ongrid): Ops AI agent that investigates infrastructure root causes and performs guarded remediation through common team-chat interfaces.
+- [Agents Observe](https://github.com/simple10/agents-observe): Real-time observability dashboard for Claude Code and Codex agents with session replay, filtering, and token usage statistics.
 - [Axon](https://github.com/langchain-tracer/Axon): OpenTelemetry-native LLM observability CLI for viewing LLM and agent traces in real time.
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval): Open-source RAG evaluation toolkit for measuring retrieval and answer quality without requiring golden answers.
 - [Observal](https://github.com/Observal/Observal): Local registry and analytics platform for governing and understanding AI agents, MCP servers, and reusable agent skills.
@@ -257,6 +258,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Argilla](https://github.com/argilla-io/argilla): Open-source collaboration platform for building, curating, and versioning high-quality datasets for LLM fine-tuning and evaluation.
 - [llmware](https://github.com/llmware-ai/llmware): Unified open-source framework for enterprise LLM applications with integrated RAG, parsing, embedding, and vector database orchestration.
 - [AgentGateway](https://github.com/agentgateway/agentgateway): Next-generation agentic proxy for AI agents and MCP servers, providing secure access, routing, and policy management for agent tool integrations.
+- [Jarvis Registry](https://github.com/ascending-llc/jarvis-registry): Enterprise MCP and A2A gateway with identity-aware access control, tool discovery, OpenTelemetry tracing, and Prometheus metrics.
 - [Maxun](https://github.com/getmaxun/maxun): Open-source no-code platform for web scraping, crawling, search, and AI data extraction, turning websites into structured APIs for RAG and AI pipelines.
 - [GPT-Researcher](https://github.com/assafelovic/gpt-researcher): Autonomous AI agent for comprehensive web research, report generation, and knowledge synthesis using multi-source data retrieval.
 - [rtk](https://github.com/rtk-ai/rtk): CLI proxy that reduces LLM token consumption by 60-90% on common dev commands, lowering AI infrastructure costs in development workflows.
@@ -535,6 +537,7 @@ A curated technology stack and toolchain for platform engineering.
 - [OpenCode](https://github.com/anomalyco/opencode): The open source coding agent — fast, lightweight CLI coding agent with low token overhead and broad LLM support.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli): Google's open-source AI agent that brings Gemini's power into the terminal for coding, file editing, and task automation.
 - [OpenWiki](https://github.com/langchain-ai/openwiki): CLI that writes and maintains agent documentation for codebases, automatically keeping docs in sync as the code evolves.
+- [VibeKit](https://github.com/superagent-ai/vibekit): Safety layer for coding agents that provides isolated sandboxes, sensitive-data redaction, and built-in execution observability.
 - [CodeBurn](https://github.com/getagentseal/codeburn): Free local tool for tracking AI coding token usage and cost across 31 tools and agents, with breakdowns by model, project, and task.
 
 ### Developer Environments

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,6 +151,7 @@
 - [OME](https://github.com/ome-projects/ome)：Kubernetes Operator，用于管理 LLM 服务、GPU 调度和模型生命周期，支持 SGLang、vLLM、TensorRT-LLM 与 Triton。
 - [AURA](https://github.com/mezmo/aura)：面向生产的安全 AI SRE Agent 驾驭框架，提供护栏、状态管理、身份认证、流式执行和运维工具集成。
 - [ongrid](https://github.com/ongridio/ongrid)：运维 AI Agent，可通过常见团队聊天界面调查基础设施根因并执行带护栏的修复。
+- [Agents Observe](https://github.com/simple10/agents-observe)：Claude Code 和 Codex Agent 的实时可观测仪表盘，支持会话回放、过滤和 Token 用量统计。
 - [Axon](https://github.com/langchain-tracer/Axon)：基于 OpenTelemetry 的 LLM 可观测性 CLI，可实时查看 LLM 和 Agent 链路。
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval)：开源 RAG 评估工具包，无需预先准备标准答案即可衡量检索和回答质量。
 - [Observal](https://github.com/Observal/Observal)：本地优先的注册与分析平台，用于治理和理解 AI Agent、MCP Server 及可复用 Agent Skill。
@@ -257,6 +258,7 @@
 - [Argilla](https://github.com/argilla-io/argilla)：面向 AI 工程师和领域专家的开源协作平台，用于构建、管理和版本化 LLM 微调与评估所需的高质量数据集。
 - [llmware](https://github.com/llmware-ai/llmware)：统一的开源框架，用于构建企业级 LLM 应用，集成 RAG、文档解析、嵌入和向量数据库编排能力。
 - [AgentGateway](https://github.com/agentgateway/agentgateway)：面向 AI Agent 和 MCP Server 的新一代代理网关，提供安全访问、路由和策略管理，用于 Agent 工具集成。
+- [Jarvis Registry](https://github.com/ascending-llc/jarvis-registry)：企业级 MCP 与 A2A 网关，提供身份感知访问控制、工具发现、OpenTelemetry 链路和 Prometheus 指标。
 - [Maxun](https://github.com/getmaxun/maxun)：开源无代码平台，支持 Web 抓取、爬取、搜索和 AI 数据提取，可将网站转化为 RAG 和 AI 流水线所需的结构化 API。
 - [GPT-Researcher](https://github.com/assafelovic/gpt-researcher)：自主 AI 研究 Agent，支持全面的 Web 研究、报告生成和知识聚合，基于多源数据检索。
 - [rtk](https://github.com/rtk-ai/rtk)：CLI 代理工具，可将日常开发命令的 LLM Token 消耗降低 60-90%，降低 AI 基础设施成本。
@@ -535,6 +537,7 @@
 - [OpenCode](https://github.com/anomalyco/opencode)：开源编码 Agent——快速、轻量的 CLI 编码工具，以低 Token 开销和广泛 LLM 支持著称。
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli)：谷歌开源的 AI Agent，将 Gemini 的强大能力带入终端，用于编码、文件编辑和任务自动化。
 - [OpenWiki](https://github.com/langchain-ai/openwiki)：用于为代码库编写和维护 Agent 文档的 CLI 工具，随代码演进自动保持文档同步。
+- [VibeKit](https://github.com/superagent-ai/vibekit)：编码 Agent 的安全层，提供隔离沙箱、敏感数据脱敏和内置执行可观测性。
 - [CodeBurn](https://github.com/getagentseal/codeburn)：免费本地工具，可追踪 31 种 AI 编码工具和 Agent 的 Token 用量与成本，按模型、项目和任务维度拆分。
 
 ### Developer Environments 开发环境


### PR DESCRIPTION
## Summary
Add a small bilingual curation batch focused on production AI operations.

## Projects added
- Agents Observe — real-time Claude Code/Codex session observability.
- Jarvis Registry — governed MCP/A2A gateway with identity and telemetry.
- VibeKit — sandbox, redaction, and observability safety layer for coding agents.

## Validation
- Markdown structural checks passed.
- Internal-link and duplicate URL/name checks passed.
- English/Chinese URL parity passed.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.
- Changed files are limited to `README.md` and `README.zh-CN.md`.

## Risk
Documentation-only additions. The listed projects are active and non-archived at review time; star counts are discovery signals, not quality guarantees.

## Auto-merge intent
Auto-merge after self-review and green or absent checks; no failing checks will be bypassed.
