### PR TITLE
docs: add AI observability and inference operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Dash0 Agent Skills](https://github.com/dash0hq/agent-skills): OpenTelemetry skills and reference material for AI coding assistants, covering instrumentation patterns and telemetry quality.
 - [Claude Code Hooks Multi-Agent Observability](https://github.com/disler/claude-code-hooks-multi-agent-observability): Real-time monitoring for Claude Code agents through simple hook-based event tracking.
 - [tma1](https://github.com/tma1-ai/tma1): Local-first observability for coding agents that records LLM calls and exposes logs, metrics, traces, and cost data through hooks and MCP.
+- [VictoriaMetrics MCP Server](https://github.com/VictoriaMetrics/mcp-victoriametrics): MCP server for querying VictoriaMetrics from AI assistants and agents, bringing time-series observability context into operational investigations.
 
 ## AI Serving and Inference Operations
 
@@ -191,6 +192,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM): NVIDIA's official LLM inference optimization framework with state-of-the-art GPU optimizations and efficient runtime orchestration for production deployments.
 - [Text Generation Inference](https://github.com/huggingface/text-generation-inference): HuggingFace's production-grade inference server for LLMs with tensor parallelism, continuous batching, and quantization support.
 - [Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference): Blazing-fast inference server for text embedding and reranking models with production-ready performance.
+- [OpenVINO Model Server](https://github.com/openvinotoolkit/model_server): Scalable inference server for OpenVINO-optimized models, exposing production-friendly APIs for deploying AI models.
 - [Axolotl](https://github.com/OpenAccess-AI-Collective/axolotl): Open-source LLM fine-tuning framework with support for LoRA, QLoRA, and full-parameter training across popular model architectures.
 - [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory): Unified framework for LLM fine-tuning with 100+ models and 50+ methods, supporting LoRA, QLoRA, and full-parameter training with web UI workflows.
 - [Unsloth](https://github.com/unslothai/unsloth): Open-source library for 2-5x faster LLM fine-tuning with significant memory reduction, supporting major model architectures and training workflows.
@@ -483,6 +485,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Aegis](https://github.com/Justin0504/Aegis): Runtime policy enforcement for AI agents with cryptographic audit trails, human approval gates, and an emergency kill switch.
 - [Tirith](https://github.com/sheeki03/tirith): Terminal security tool for developers and AI agents that intercepts homograph URLs, pipe-to-shell, ANSI injection, obfuscated payloads, and data exfiltration before execution.
 - [Varlock](https://github.com/dmno-dev/varlock): AI-safe environment variable format that separates machine-readable schemas for agents from human-readable secrets, preventing accidental credential exposure in agent configs.
+- [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner): Security scanner for AI agent skills that detects malicious patterns, vulnerabilities, and other risks before skills are used.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,6 +159,7 @@
 - [Dash0 Agent Skills](https://github.com/dash0hq/agent-skills)：面向 AI 编码助手的 OpenTelemetry Skill 与参考资料，涵盖插桩模式和遥测质量指南。
 - [Claude Code Hooks Multi-Agent Observability](https://github.com/disler/claude-code-hooks-multi-agent-observability)：通过简单的 Hook 事件追踪，实时监控 Claude Code Agent。
 - [tma1](https://github.com/tma1-ai/tma1)：本地优先的编码 Agent 可观测性工具，通过 Hook 和 MCP 记录 LLM 调用，并提供日志、指标、链路和成本数据。
+- [VictoriaMetrics MCP Server](https://github.com/VictoriaMetrics/mcp-victoriametrics)：用于从 AI 助手和 Agent 查询 VictoriaMetrics 的 MCP Server，将时序可观测数据带入运维调查。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 
@@ -191,6 +192,7 @@
 - [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)：NVIDIA 官方 LLM 推理优化框架，提供先进的 GPU 优化和高效的运行时编排能力，适用于生产环境部署。
 - [Text Generation Inference](https://github.com/huggingface/text-generation-inference)：HuggingFace 的生产级 LLM 推理服务器，支持张量并行、连续批处理和量化。
 - [Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference)：极速文本嵌入与重排序模型推理服务器，具备生产就绪性能。
+- [OpenVINO Model Server](https://github.com/openvinotoolkit/model_server)：面向 OpenVINO 优化模型的可扩展推理服务器，提供适合生产部署 AI 模型的 API。
 - [Axolotl](https://github.com/OpenAccess-AI-Collective/axolotl)：开源 LLM 微调框架，支持 LoRA、QLoRA 和全参数训练，覆盖主流模型架构。
 - [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory)：统一 LLM 微调框架，支持 100+ 模型和 50+ 方法，涵盖 LoRA、QLoRA 和全参数训练，提供 Web UI 工作流。
 - [Unsloth](https://github.com/unslothai/unsloth)：开源 LLM 微调加速库，可将微调速度提升 2-5 倍并显著降低内存占用，支持主流模型架构与训练工作流。
@@ -483,6 +485,7 @@
 - [Aegis](https://github.com/Justin0504/Aegis)：AI Agent 运行时策略执行工具，提供加密审计轨迹、人机审批门禁和紧急停止开关。
 - [Tirith](https://github.com/sheeki03/tirith)：面向开发者和 AI Agent 的终端安全工具，在执行前拦截同形异义 URL、管道注入、ANSI 注入、混淆载荷和数据泄露。
 - [Varlock](https://github.com/dmno-dev/varlock)：AI 安全的环境变量格式，将面向 Agent 的机器可读 Schema 与面向人类的 Secret 分离，防止 Agent 配置中的凭据意外泄露。
+- [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner)：AI Agent Skill 安全扫描器，可在使用 Skill 前检测恶意模式、漏洞和其他风险。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
Add three production-oriented AI operations tools to both README language variants.

## Projects added
- VictoriaMetrics MCP Server — query time-series observability data from AI assistants and agents.
- OpenVINO Model Server — scalable serving for OpenVINO-optimized models.
- Cisco Skill Scanner — security scanning for AI agent skills.

## Validation
- Markdown structural checks passed for both READMEs.
- Internal links and duplicate URLs/project names checked.
- Candidate repositories verified with GitHub API; all are active and non-archived.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD (`e6979bbf54c4c4fbf351428834f4a2ed7877cb49`).
- Diff limited to `README.md` and `README.zh-CN.md`.

## Risk
Documentation-only change. Main risk is future project maturity or scope drift; descriptions are intentionally concise and operationally scoped.

## Auto-merge intent
After self-review and checks, squash-merge this focused documentation PR.