### PR TITLE
docs: add AI agent governance gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [ToolHive](https://github.com/stacklok/toolhive): Enterprise platform for securely running and managing MCP servers with isolation, lifecycle controls, and operational governance.
 - [Tracecat](https://github.com/TracecatHQ/tracecat): Open-source security automation platform for teams and AI agents with event-driven orchestration, monitoring, and low-code workflows.
 - [OneCLI](https://github.com/onecli/onecli): Open-source credential gateway with built-in vault for giving AI agents access to services without exposing secrets.
+- [Preloop](https://github.com/preloop/preloop): Self-hostable AI agent control plane combining an MCP firewall, model gateway, policy-as-code, human approvals, runtime observability, budgets, and audit trails.
+- [hoop](https://github.com/hoophq/hoop): Open-source layer-7 gateway for engineers and AI agents that masks sensitive data, blocks dangerous infrastructure operations, supports approvals, and records sessions across databases, Kubernetes, SSH, APIs, and MCP.
 - [OpenAnt](https://github.com/knostic/OpenAnt): Open-source LLM-based vulnerability discovery tool for proactively finding verified security flaws in AI systems.
 - [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard): Full-stack AI red teaming platform for scanning AI infrastructure, agents, skills, MCP servers, and LLM jailbreak vulnerabilities.
 - [Cybersecurity AI (CAI)](https://github.com/aliasrobotics/cai): Open-source framework for applying AI agents to cybersecurity research and defensive security workflows.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -462,6 +462,8 @@
 - [ToolHive](https://github.com/stacklok/toolhive)：企业级 MCP Server 安全运行与管理平台，提供隔离、生命周期控制和运维治理能力。
 - [Tracecat](https://github.com/TracecatHQ/tracecat)：面向团队和 AI Agent 的开源安全自动化平台，支持事件驱动编排、监控和低代码工作流。
 - [OneCLI](https://github.com/onecli/onecli)：开源凭据网关，内置密钥保险库，让 AI Agent 无需暴露密钥即可安全访问服务。
+- [Preloop](https://github.com/preloop/preloop)：可自托管的 AI Agent 控制平面，整合 MCP 防火墙、模型网关、policy-as-code、人机审批、运行时可观测性、预算和审计轨迹。
+- [hoop](https://github.com/hoophq/hoop)：开源七层网关，面向工程师和 AI Agent 对数据库、Kubernetes、SSH、API 与 MCP 访问执行敏感数据脱敏、危险操作拦截、审批和会话记录。
 - [OpenAnt](https://github.com/knostic/OpenAnt)：基于 LLM 的开源漏洞发现工具，可主动发现 AI 系统中经过验证的安全漏洞。
 - [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard)：全栈 AI 红队平台，用于扫描 AI 基础设施、Agent、技能、MCP Server 和 LLM 越狱漏洞。
 - [Cybersecurity AI (CAI)](https://github.com/aliasrobotics/cai)：开源框架，用于将 AI Agent 应用于网络安全研究和防御性安全工作流。


### PR DESCRIPTION
## Summary
Add two production-oriented AI agent governance and infrastructure access gateways to the security and supply-chain map.

## Projects added
- Preloop — self-hostable agent control plane with MCP firewall, model gateway, policy-as-code, approvals, observability, budgets, and audit trails.
- hoop — layer-7 gateway for masking sensitive data, blocking dangerous operations, approvals, and session recording across infrastructure protocols and MCP.

## Validation
- Markdown internal-link, duplicate URL/name, and bilingual GitHub URL parity checks passed.
- git diff --check passed.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Changed files limited to README.md and README.zh-CN.md.
- Remote branch SHA matches local HEAD.

## Risk
Documentation-only change. Candidate repositories were checked as actively maintained and unarchived at review time; star counts were used only as discovery signals.

## Auto-merge intent
Self-review and checks will be completed before squash merging. Merge only if the diff remains limited to the expected bilingual README entries and checks are green or absent.