### PR TITLE
docs: add Kueue for AI workload queueing

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [MinIO](https://github.com/minio/minio): High-performance, S3-compatible object storage with native Kubernetes support for AI/ML data lakes, analytics, and cloud-native applications.
 - [KubeVirt](https://github.com/kubevirt/kubevirt): Kubernetes-native virtualization platform for running and managing virtual machines alongside containers on Kubernetes.
 - [KubeSphere](https://github.com/kubesphere/kubesphere): Container platform for multi-cloud, datacenter, and edge Kubernetes management with integrated DevOps, observability, service mesh, and multi-tenancy.
+- [Kueue](https://github.com/kubernetes-sigs/kueue): Kubernetes-native job queueing system for managing batch, AI/ML, and other queued workloads with quotas and fair sharing.
 
 ## Security and Supply Chain
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -439,6 +439,7 @@
 - [MinIO](https://github.com/minio/minio)：高性能 S3 兼容对象存储，原生支持 Kubernetes，适用于 AI/ML 数据湖、分析和云原生应用。
 - [KubeVirt](https://github.com/kubevirt/kubevirt)：Kubernetes 原生虚拟化平台，可在 Kubernetes 上与容器一同运行和管理虚拟机。
 - [KubeSphere](https://github.com/kubesphere/kubesphere)：面向多云、数据中心和边缘 Kubernetes 管理的容器平台，集成 DevOps、可观测性、服务网格和多租户能力。
+- [Kueue](https://github.com/kubernetes-sigs/kueue)：Kubernetes 原生作业排队系统，用于通过配额和公平共享管理批处理、AI/ML 及其他排队工作负载。
 
 ## Security and Supply Chain 安全与供应链
 


### PR DESCRIPTION
## Summary
Add one production-oriented Kubernetes workload scheduling project to strengthen the AI infrastructure operations map.

## Projects added
- Kueue — Kubernetes-native job queueing with quotas and fair sharing for batch and AI/ML workloads.

## Validation
- Markdown internal-link and duplicate URL/name checks passed.
- English/Chinese README URL parity passed: 493 entries in each file.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.
- Self-review: changed files are limited to `README.md` and `README.zh-CN.md`; bilingual descriptions are semantically aligned.

## Risk
Low: documentation-only change; no runtime or dependency impact.

## Auto-merge intent
After PR self-review and checks are green or absent, squash merge and delete the branch.