### PR TITLE
docs: add auditable AI coding workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ A curated technology stack and toolchain for platform engineering.
 - [OpenWiki](https://github.com/langchain-ai/openwiki): CLI that writes and maintains agent documentation for codebases, automatically keeping docs in sync as the code evolves.
 - [VibeKit](https://github.com/superagent-ai/vibekit): Safety layer for coding agents that provides isolated sandboxes, sensitive-data redaction, and built-in execution observability.
 - [CodeBurn](https://github.com/getagentseal/codeburn): Free local tool for tracking AI coding token usage and cost across 31 tools and agents, with breakdowns by model, project, and task.
+- [h5i](https://github.com/h5i-dev/h5i): Apache-2.0 platform for auditable AI coding-agent workspaces, with sandboxed Git worktrees, multi-agent orchestration, prompt and context tracking, review gates, and token-efficient logs.
 
 ### Developer Environments
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -552,6 +552,7 @@
 - [OpenWiki](https://github.com/langchain-ai/openwiki)：用于为代码库编写和维护 Agent 文档的 CLI 工具，随代码演进自动保持文档同步。
 - [VibeKit](https://github.com/superagent-ai/vibekit)：编码 Agent 的安全层，提供隔离沙箱、敏感数据脱敏和内置执行可观测性。
 - [CodeBurn](https://github.com/getagentseal/codeburn)：免费本地工具，可追踪 31 种 AI 编码工具和 Agent 的 Token 用量与成本，按模型、项目和任务维度拆分。
+- [h5i](https://github.com/h5i-dev/h5i)：Apache-2.0 许可的 AI 编码 Agent 可审计工作区平台，提供隔离 Git worktree、多 Agent 编排、Prompt 与上下文追踪、评审门禁和高效日志压缩。
 
 ### Developer Environments 开发环境
 


### PR DESCRIPTION
## Summary
Add h5i to the AI coding tools section as an auditable, sandboxed workspace and multi-agent orchestration platform.

## Projects added
- h5i — sandboxed Git worktrees, prompt/context tracking, review gates, and token-efficient logs.

## Validation
- Markdown structural checks passed for both READMEs.
- Internal links and duplicate URLs/project names checked.
- English/Chinese entry parity checked.
- Diff limited to README.md and README.zh-CN.md.
- Rebasing onto latest origin/main completed; origin/main is an ancestor of HEAD.

## Risk
Low: documentation-only change; project details were checked against the upstream repository and GitHub metadata.

## Auto-merge intent
Self-review first; merge only if the diff is expected and checks are green or absent.