### PR TITLE
docs: add NVIDIA NVCF and Grove to AI Serving and Inference Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [Agent Lightning](https://github.com/microsoft/agent-lightning): Framework for training and optimizing AI agents by connecting agent execution with reinforcement learning and other training methods.
 - [verl](https://github.com/verl-project/verl): Flexible and efficient reinforcement-learning framework for post-training large language models and optimizing reasoning or agent workloads.
 - [aikit](https://github.com/kaito-project/aikit): Kubernetes-native toolkit for fine-tuning, building, and deploying open-source LLMs with buildkit-based image construction and GPU-accelerated inference.
+- [NVIDIA NVCF](https://github.com/NVIDIA/nvcf): Platform for deploying and routing GPU-accelerated inference, streaming, and batch workloads at scale.
+- [Grove](https://github.com/ai-dynamo/grove): Kubernetes enhancements for topology-aware gang scheduling and autoscaling of distributed AI workloads.
 
 ## AIOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -211,6 +211,8 @@
 - [Agent Lightning](https://github.com/microsoft/agent-lightning)：用于训练和优化 AI Agent 的框架，可将 Agent 执行过程连接到强化学习及其他训练方法。
 - [verl](https://github.com/verl-project/verl)：灵活高效的大语言模型后训练强化学习框架，可用于优化推理和 Agent 工作负载。
 - [aikit](https://github.com/kaito-project/aikit)：Kubernetes 原生工具包，支持基于 buildkit 的镜像构建和 GPU 加速推理，用于微调、构建和部署开源 LLM。
+- [NVIDIA NVCF](https://github.com/NVIDIA/nvcf)：用于大规模部署和路由 GPU 加速推理、流式处理及批处理工作负载的平台。
+- [Grove](https://github.com/ai-dynamo/grove)：面向分布式 AI 工作负载的 Kubernetes 增强组件，支持拓扑感知的 Gang 调度和自动扩缩容。
 
 ## AIOps 智能运维
 


### PR DESCRIPTION
## Summary

Add two new entries to the **AI Serving and Inference Operations** section, strengthening GPU inference routing and Kubernetes scheduling coverage for production AI workloads.

## Projects Added

1. **NVIDIA NVCF** — Platform for deploying and routing GPU-accelerated inference, streaming, and batch workloads at scale. (GitHub: `NVIDIA/nvcf`, 183 stars, actively maintained, pushed 2026-07-26)
2. **Grove** — Kubernetes enhancements for topology-aware gang scheduling and autoscaling of distributed AI workloads. (GitHub: `ai-dynamo/grove`, 244 stars, actively maintained, pushed 2026-07-24)

## Validation

- ✅ Both entries added to `README.md` (English) and `README.zh-CN.md` (Simplified Chinese) with equivalent descriptions.
- ✅ No duplicate URLs or entry names detected (markdown structural validation passed).
- ✅ No duplicate of existing entries verified by name, URL, and org/repo check.
- ✅ Diff scope limited to `README.md` and `README.zh-CN.md` only.
- ✅ Branch rebased on latest `origin/main`; `origin/main` is ancestor of HEAD.
- ✅ Local HEAD SHA matches remote branch SHA after push.
- ✅ GitHub star counts verified via `gh api repos/<owner>/<repo>` — not guessed.

## Risk

- Low risk: docs-only change, 2 new entries in an existing section.
- Both projects are from credible organizations (NVIDIA, ai-dynamo) with active maintenance.
- Grove is relatively new (244 stars) but fills a distinct gap in topology-aware gang scheduling for distributed AI on Kubernetes.

## Auto-merge intent

Self-review completed. Will auto-merge with `gh pr merge --squash --delete-branch` if checks are green or absent.