### PR TITLE
docs: add agents-cli to AI coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ A curated technology stack and toolchain for platform engineering.
 
 ### AI Coding Tools
 
+- [agents-cli](https://github.com/google/agents-cli): CLI and reusable skills for scaffolding, evaluating, deploying, publishing, and observing production AI agents on Google Cloud.
 - [Aider](https://github.com/Aider-AI/aider): AI pair programming tool that works in your terminal with multi-file editing, git integration, and support for leading LLMs.
 - [Continue](https://github.com/continuedev/continue): Open-source AI code assistant that integrates with IDEs as an autopilot for software development with customizable context and models.
 - [Tabby](https://github.com/TabbyML/tabby): Self-hosted AI coding assistant with code completion, chat, and agent capabilities that can run fully on-premises.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -537,6 +537,7 @@
 
 ### AI Coding Tools AI 编码工具
 
+- [agents-cli](https://github.com/google/agents-cli)：用于在 Google Cloud 上构建生产级 AI Agent 的 CLI 与可复用 Skill，覆盖脚手架、评估、部署、发布和可观测性。
 - [Aider](https://github.com/Aider-AI/aider)：终端中的 AI 结对编程工具，支持多文件编辑、Git 集成和主流 LLM。
 - [Continue](https://github.com/continuedev/continue)：开源 AI 代码助手，以自动驾驶模式集成到 IDE 中，支持自定义上下文和模型。
 - [Tabby](https://github.com/TabbyML/tabby)：自托管的 AI 编码助手，提供代码补全、对话和 Agent 能力，可完全在本地运行。


### PR DESCRIPTION
## Summary
Add the current Google `agents-cli` project to the AI Coding Tools section in both README language variants.

## Projects/content added
- [agents-cli](https://github.com/google/agents-cli): CLI and reusable skills for scaffolding, evaluating, deploying, publishing, and observing production AI agents on Google Cloud.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese entries contain the same canonical project URL.
- `git diff --check` passed.
- Diff limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.
- Self-review completed; changed files and bilingual descriptions are aligned.

## Risk
Documentation-only change. The project README indicates `agents-cli` is the active successor to Agent Starter Pack; this entry avoids listing the maintenance-mode predecessor.

## Auto-merge intent
Auto-merge after self-review and successful/absent checks, using squash merge. No checks are currently required/known to block the PR.