### PR TITLE
docs: add ClawBench agent evaluation framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [BigQuery Agent Analytics SDK](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK): Open-source Python SDK for analyzing, evaluating, and curating production agent traces stored in BigQuery.
 - [Claude Code Hooks Multi-Agent Observability](https://github.com/disler/claude-code-hooks-multi-agent-observability): Real-time monitoring and visualization for Claude Code agent swarms through hook event tracking, session filters, and live updates.
 - [MC Agent Toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit): Agent skills and plugins that bring data lineage, monitoring, validation, alerting, and metadata checks into AI coding workflows.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench): Open-source benchmark and runner for evaluating browser agents on live websites, with 283 tasks and five-layer recordings spanning video, screenshots, HTTP traffic, browser actions, and agent messages.
 
 ## AI Serving and Inference Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,6 +167,7 @@
 - [BigQuery Agent Analytics SDK](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK)：开源 Python SDK，用于分析、评估和整理存储在 BigQuery 中的生产 Agent trace。
 - [Claude Code Hooks Multi-Agent Observability](https://github.com/disler/claude-code-hooks-multi-agent-observability)：通过 Hook 事件追踪、会话过滤和实时更新，监控并可视化 Claude Code Agent 集群。
 - [MC Agent Toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit)：将数据血缘、监控、校验、告警和元数据检查能力带入 AI 编码工作流的 Agent Skill 与插件工具包。
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench)：用于在真实网站上评测浏览器 Agent 的开源基准与运行框架，包含 283 项任务，并以会话视频、操作截图、HTTP 流量、浏览器动作和 Agent 消息进行五层记录。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 


### PR DESCRIPTION
## Summary

- Add ClawBench to the LLM and Agent Observability section in both English and Simplified Chinese.
- Describe its live-website browser-agent evaluation and five-layer recording support in one factual sentence per language.

## Why it belongs

ClawBench is an open-source benchmark and runner for evaluating browser agents on live websites. Its synchronized video, screenshot, HTTP-traffic, browser-action, and agent-message capture makes agent runs inspectable for evaluation and diagnosis, matching this section and the production-oriented curation scope.

## Validation

- Kept the English and Chinese GitHub entry sets in parity.
- Confirmed the canonical GitHub and arXiv links return HTTP 200.
- Ran `git diff --check`.
- Searched the default branch and REST all-state pull request and issue history for existing ClawBench entries.

## Disclosure

I am a ClawBench maintainer and am submitting this entry transparently for maintainer review.

Automated assistance was used to audit the contribution rules, check for duplicates, draft the bilingual entries, and validate the focused diff. I verified the claims against the official ClawBench repository and arXiv record.