### PR TITLE
docs: add EvalScope and Kiln to LLM evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Agents Observe](https://github.com/simple10/agents-observe): Real-time observability dashboard for Claude Code and Codex agents with session replay, filtering, and token usage statistics.
 - [Axon](https://github.com/langchain-tracer/Axon): OpenTelemetry-native LLM observability CLI for viewing LLM and agent traces in real time.
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval): Open-source RAG evaluation toolkit for measuring retrieval and answer quality without requiring golden answers.
+- [EvalScope](https://github.com/modelscope/evalscope): LLM evaluation framework for capability benchmarks, agent-loop evaluation with recorded traces, inference performance testing, and interactive result analysis.
+- [Kiln](https://github.com/Kiln-AI/kiln): Open-source workbench for building and improving AI systems with collaborative evals, prompt optimization, RAG, agents, synthetic data, and production deployment support.
 - [Observal](https://github.com/Observal/Observal): Local registry and analytics platform for governing and understanding AI agents, MCP servers, and reusable agent skills.
 - [Agent Prism](https://github.com/evilmartians/agent-prism): React components for visualizing AI agent traces and making multi-step agent execution easier to inspect.
 - [Dash0 Agent Skills](https://github.com/dash0hq/agent-skills): OpenTelemetry skills and reference material for AI coding assistants, covering instrumentation patterns and telemetry quality.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,6 +158,8 @@
 - [Agents Observe](https://github.com/simple10/agents-observe)：Claude Code 和 Codex Agent 的实时可观测仪表盘，支持会话回放、过滤和 Token 用量统计。
 - [Axon](https://github.com/langchain-tracer/Axon)：基于 OpenTelemetry 的 LLM 可观测性 CLI，可实时查看 LLM 和 Agent 链路。
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval)：开源 RAG 评估工具包，无需预先准备标准答案即可衡量检索和回答质量。
+- [EvalScope](https://github.com/modelscope/evalscope)：LLM 评估框架，支持能力基准测试、带 trace 记录的 Agent Loop 评估、推理性能测试和交互式结果分析。
+- [Kiln](https://github.com/Kiln-AI/kiln)：用于构建和改进 AI 系统的开源工作台，支持协作式评估、Prompt 优化、RAG、Agent、合成数据和生产部署。
 - [Observal](https://github.com/Observal/Observal)：本地优先的注册与分析平台，用于治理和理解 AI Agent、MCP Server 及可复用 Agent Skill。
 - [Agent Prism](https://github.com/evilmartians/agent-prism)：用于可视化 AI Agent trace 的 React 组件，帮助检查多步骤 Agent 执行过程。
 - [Dash0 Agent Skills](https://github.com/dash0hq/agent-skills)：面向 AI 编码助手的 OpenTelemetry Skill 与参考资料，涵盖插桩模式和遥测质量指南。


### PR DESCRIPTION
## Summary

- Add EvalScope and Kiln to the LLM and Agent Observability section.
- Keep English and Simplified Chinese entries aligned with concise, operations-relevant descriptions.

## Projects added

- [EvalScope](https://github.com/modelscope/evalscope): capability and agent-loop evaluation, trace recording, inference performance testing, and result analysis.
- [Kiln](https://github.com/Kiln-AI/kiln): collaborative AI-system workbench covering evals, prompt optimization, RAG, agents, synthetic data, and production deployment.

## Validation

- Markdown internal-link, duplicate URL/name, and bilingual URL-parity checks passed.
- `git diff --check` passed.
- Diff contains only `README.md` and `README.zh-CN.md`.
- Branch rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Self-review completed: bilingual entries are semantically aligned and the descriptions match the upstream repository README claims.

## Risk

Documentation-only change; low runtime risk. Project capabilities and activity can evolve, so descriptions should be revisited during future curation.

## Auto-merge intent

Auto-merge after self-review and checks are green or absent, using squash merge and remote branch deletion.
