### PR TITLE
docs: add NeMo Relay, Qtap, and Cube Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [abtop](https://github.com/graykode/abtop): htop-style terminal monitor for AI coding agent sessions, tokens, context windows, rate limits, and ports.
 - [agenttrace](https://github.com/luoyuctl/agenttrace): Local-first TUI for inspecting AI coding agent cost, tokens, latency, failures, and reports.
 - [OpenTelemetry MCP Server](https://github.com/traceloop/opentelemetry-mcp-server): Unified MCP server for querying OpenTelemetry traces across Jaeger, Tempo, Traceloop, and other backends so AI agents can investigate distributed systems.
+- [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay): Multi-language agent runtime and middleware library for managing execution scopes, lifecycle events, and tool or LLM call telemetry.
 - [Kitaru](https://github.com/zenml-io/kitaru): Production AI agent recording and replay toolkit for analyzing runs and improving agent behavior.
 - [ax](https://github.com/Necmttn/ax): Local-first telemetry and memory graph for AI coding agents, covering costs, tools, skills, sessions, and OTLP events.
 - [Mindwalk](https://github.com/cosmtrek/mindwalk): Visualization tool that replays coding-agent sessions on a 3D map of your codebase for debugging and understanding agent behavior.
@@ -218,6 +219,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [aikit](https://github.com/kaito-project/aikit): Kubernetes-native toolkit for fine-tuning, building, and deploying open-source LLMs with buildkit-based image construction and GPU-accelerated inference.
 - [NVIDIA NVCF](https://github.com/NVIDIA/nvcf): Platform for deploying and routing GPU-accelerated inference, streaming, and batch workloads at scale.
 - [Grove](https://github.com/ai-dynamo/grove): Kubernetes enhancements for topology-aware gang scheduling and autoscaling of distributed AI workloads.
+- [Cube Studio](https://github.com/data-infra/cube-studio): Cloud-native AI platform for Kubernetes with MLOps workflows, distributed training, GPU virtualization, inference serving, and LLMOps capabilities.
 
 ## AIOps
 
@@ -404,6 +406,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Superlog](https://github.com/superloglabs/superlog): Open-source observability tool that uses AI agents to self-heal software by detecting issues and automating fixes.
 - [Monoscope](https://github.com/monoscope-tech/monoscope): Open-source observability platform with S3-native storage, OpenTelemetry-native ingest, natural language queries, and AI agents for anomaly detection and scheduled reports.
 - [DeepFlow](https://github.com/deepflowio/deepflow): eBPF-based observability platform for distributed tracing, profiling, network telemetry, and automatic application topology discovery.
+- [Qtap](https://github.com/qpoint-io/qtap): eBPF agent that captures pre-encrypted network traffic with process, container, host, and protocol context for security auditing and troubleshooting.
 - [Parseable](https://github.com/parseablehq/parseable): Rust-based, data-lake observability platform for logs, metrics, traces, and events across applications, agents, and infrastructure.
 - [Traccia](https://github.com/traccia-ai/traccia-py): OpenTelemetry-based Python SDK for AI-agent tracing, token and cost tracking, guardrail detection, governance evidence, and OTLP export.
 - [PandaProbe](https://github.com/chirpz-ai/pandaprobe): Open-source agent engineering platform for traces, evaluations, and metrics across LangGraph, CrewAI, Claude Agent SDK, and other agent runtimes.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,6 +76,7 @@
 - [abtop](https://github.com/graykode/abtop)：类似 htop 的终端监控工具，用于查看 AI 编码 Agent 会话、Token、上下文窗口、速率限制和端口。
 - [agenttrace](https://github.com/luoyuctl/agenttrace)：本地优先的 TUI，用于检查 AI 编码 Agent 的成本、Token、延迟、失败和报告。
 - [OpenTelemetry MCP Server](https://github.com/traceloop/opentelemetry-mcp-server)：统一的 MCP Server，可查询 Jaeger、Tempo、Traceloop 等后端的 OpenTelemetry 链路，让 AI Agent 能够调查分布式系统。
+- [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay)：多语言 Agent 运行时与中间件库，用于管理执行作用域、生命周期事件以及工具或 LLM 调用遥测。
 - [Kitaru](https://github.com/zenml-io/kitaru)：面向生产环境的 AI Agent 录制与回放工具，用于分析运行过程并改进 Agent 行为。
 - [ax](https://github.com/Necmttn/ax)：面向 AI 编码 Agent 的本地优先遥测与记忆图，覆盖成本、工具、技能、会话和 OTLP 事件。
 - [Mindwalk](https://github.com/cosmtrek/mindwalk)：可视化工具，在代码库 3D 地图上回放编码 Agent 会话，帮助调试和理解 Agent 行为。
@@ -218,6 +219,7 @@
 - [aikit](https://github.com/kaito-project/aikit)：Kubernetes 原生工具包，支持基于 buildkit 的镜像构建和 GPU 加速推理，用于微调、构建和部署开源 LLM。
 - [NVIDIA NVCF](https://github.com/NVIDIA/nvcf)：用于大规模部署和路由 GPU 加速推理、流式处理及批处理工作负载的平台。
 - [Grove](https://github.com/ai-dynamo/grove)：面向分布式 AI 工作负载的 Kubernetes 增强组件，支持拓扑感知的 Gang 调度和自动扩缩容。
+- [Cube Studio](https://github.com/data-infra/cube-studio)：面向 Kubernetes 的云原生 AI 平台，提供 MLOps 工作流、分布式训练、GPU 虚拟化、推理服务和 LLMOps 能力。
 
 ## AIOps 智能运维
 
@@ -404,6 +406,7 @@
 - [Superlog](https://github.com/superloglabs/superlog)：开源可观测性工具，利用 AI Agent 检测问题并自动修复，实现软件自愈。
 - [Monoscope](https://github.com/monoscope-tech/monoscope)：开源可观测平台，支持 S3 原生存储、OpenTelemetry 原生采集、自然语言查询和 AI Agent 驱动的异常检测与定时报告。
 - [DeepFlow](https://github.com/deepflowio/deepflow)：基于 eBPF 的可观测平台，支持分布式追踪、性能剖析、网络遥测和自动应用拓扑发现。
+- [Qtap](https://github.com/qpoint-io/qtap)：基于 eBPF 的 Agent，可捕获加密前的网络流量及进程、容器、主机和协议上下文，用于安全审计与故障排查。
 - [Parseable](https://github.com/parseablehq/parseable)：基于 Rust 和数据湖架构的可观测平台，统一采集应用、Agent 和基础设施的日志、指标、链路与事件。
 - [Traccia](https://github.com/traccia-ai/traccia-py)：基于 OpenTelemetry 的 Python SDK，支持 AI Agent 追踪、Token 与成本统计、护栏检测、治理证据和 OTLP 导出。
 - [PandaProbe](https://github.com/chirpz-ai/pandaprobe)：开源 Agent 工程平台，面向 LangGraph、CrewAI、Claude Agent SDK 等运行时提供链路、评估和指标能力。


### PR DESCRIPTION
## Summary

Add three production-oriented X-Ops projects to the bilingual catalog:
- NeMo Relay for agent runtime lifecycle and tool/LLM telemetry.
- Qtap for eBPF network visibility and security troubleshooting.
- Cube Studio for Kubernetes-based AI/ML platform and inference operations.

## Projects added

- `NVIDIA/NeMo-Relay` — LLM and Agent Observability
- `qpoint-io/qtap` — Observability
- `data-infra/cube-studio` — AI Serving and Inference Operations

## Validation

- English and Simplified Chinese README URL sets are identical.
- No duplicate project URLs or entry names detected.
- Internal Markdown links exist.
- `git diff --check` passed.
- Changed files are limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Verified pushed branch SHA matches local HEAD (`604a662cb29203a4a96fec133051b2d5d3caa96a`).

## Risk

Documentation-only change. Candidate descriptions are concise and based on the projects' current GitHub metadata and README material. Qtap requires Linux eBPF and elevated host capabilities at runtime; this entry does not change repository behavior.

## Auto-merge intent

After self-review and green or absent checks, squash merge this focused documentation PR and delete the branch.
