### PR TITLE
docs: add production agent and MCP security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [LiveKit Agents](https://github.com/livekit/agents): Framework for building production-ready realtime voice and multimodal AI agents with integrations for models, tools, and telephony.
 - [Heym](https://github.com/heymrun/heym): Self-hosted AI workflow platform with visual and prompt-driven workflows, RAG, MCP, human approval, observability, evaluations, and token-cost tracking.
 - [Rapida](https://github.com/rapidaai/voice-ai): Open-source, end-to-end voice AI orchestration platform for real-time agents, integrating audio streaming, STT, TTS, VAD, multi-channel delivery, and observability.
+- [Google Cloud Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack): Production-oriented templates for deploying AI agents to Google Cloud with built-in CI/CD, evaluation, observability, and common enterprise integrations.
 
 ## DataOps
 
@@ -507,6 +508,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Tirith](https://github.com/sheeki03/tirith): Terminal security tool for developers and AI agents that intercepts homograph URLs, pipe-to-shell, ANSI injection, obfuscated payloads, and data exfiltration before execution.
 - [Varlock](https://github.com/dmno-dev/varlock): AI-safe environment variable format that separates machine-readable schemas for agents from human-readable secrets, preventing accidental credential exposure in agent configs.
 - [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner): Security scanner for AI agent skills that detects malicious patterns, vulnerabilities, and other risks before skills are used.
+- [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner): Security scanner for MCP servers that identifies potential threats and security findings before agents depend on their tool integrations.
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard): OWASP project defining inspectable, traceable, and instrumentable observability practices for trustworthy AI agents.
 
 ## Platform Engineering

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -346,6 +346,7 @@
 - [LiveKit Agents](https://github.com/livekit/agents)：用于构建生产级实时语音和多模态 AI Agent 的框架，集成模型、工具和电话系统。
 - [Heym](https://github.com/heymrun/heym)：可自托管的 AI 工作流平台，支持可视化和 Prompt 驱动工作流、RAG、MCP、人机审批、可观测性、评估和 Token 成本追踪。
 - [Rapida](https://github.com/rapidaai/voice-ai)：开源端到端语音 AI 编排平台，面向实时 Agent，集成音频流、STT、TTS、VAD、多渠道交付和可观测性。
+- [Google Cloud Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack)：面向生产的 AI Agent 部署模板，可将 Agent 部署到 Google Cloud，并内置 CI/CD、评估、可观测性和常见企业集成。
 
 ## DataOps
 
@@ -507,6 +508,7 @@
 - [Tirith](https://github.com/sheeki03/tirith)：面向开发者和 AI Agent 的终端安全工具，在执行前拦截同形异义 URL、管道注入、ANSI 注入、混淆载荷和数据泄露。
 - [Varlock](https://github.com/dmno-dev/varlock)：AI 安全的环境变量格式，将面向 Agent 的机器可读 Schema 与面向人类的 Secret 分离，防止 Agent 配置中的凭据意外泄露。
 - [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner)：AI Agent Skill 安全扫描器，可在使用 Skill 前检测恶意模式、漏洞和其他风险。
+- [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner)：MCP Server 安全扫描器，可在 Agent 依赖工具集成前识别潜在威胁和安全问题。
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard)：OWASP 项目，为可信 AI Agent 定义可检查、可追踪和可插桩的可观测性实践。
 
 ## Platform Engineering 平台工程


### PR DESCRIPTION
## Summary

- Add Google Cloud Agent Starter Pack to the Agentic Workflow section.
- Add Cisco MCP Scanner to Security and Supply Chain.
- Keep English and Simplified Chinese entries aligned.

## Projects added

- GoogleCloudPlatform/agent-starter-pack — production-oriented AI agent deployment templates with CI/CD, evaluation, and observability.
- cisco-ai-defense/mcp-scanner — MCP server security scanning for potential threats and findings.

## Validation

- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- `git diff --check` passed.
- Canonical GitHub URLs returned HTTP 200.
- Diff contains only `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Verified remote branch SHA matches local HEAD.

## Risk

Documentation-only change; descriptions are concise and based on the projects' current GitHub metadata. No runtime behavior is affected.

## Auto-merge intent

Auto-merge after self-review and green or absent checks. Do not bypass failing checks.
