### PR TITLE
docs: add agent evaluation and replay tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,11 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [agent-inspect](https://github.com/rajudandigam/agent-inspect): Local TypeScript agent debugging and regression-testing toolkit that turns runs into execution trees, deterministic contracts, CI gates, and safe evidence bundles.
 - [brain0](https://github.com/Brain0-ai/brain0): Offline decision graph for AI-written code that links commits to agent prompts and read context, with drift detection, DLP auditing, risk signals, and signed provenance.
 - [TokenTelemetry](https://github.com/VasiHemanth/tokentelemetry): Local dashboard for tracking tokens, costs, tool calls, sessions, and reasoning across coding and autonomous agents.
-- [Zabbix MCP Server](https://github.com/initMAX/zabbix-mcp-server): MCP server exposing the Zabbix API to AI assistants, with multi-server support, OAuth 2.1, reports, and operational tooling for infrastructure investigations.
+- [Agent-Blackbox](https://github.com/TaewoooPark/Agent-Blackbox): Local-first flight recorder and context-efficiency profiler for coding agents, with replayable session maps, cost analysis, and task-outcome signals.
+- [Mira](https://github.com/everruns/mira): Rust-first evaluation framework for multi-turn, tool-using, long-running agent trajectories with operational budgets and CI-native reports.
+- [aws-bench](https://github.com/aws-bench/aws-bench): Benchmark for evaluating coding agents on real AWS tasks in disposable environments, with verifiers for diagnosis, provisioning, and operations.
+- [claw-swe-bench](https://github.com/opensquilla/claw-swe-bench): Adapter framework for evaluating OpenClaw-style agent harnesses on reproducible SWE-bench issue-resolution tasks.
+- [OpenAgent Eval](https://github.com/OpenAgentHQ/openagent-eval): Local-first, framework-agnostic evaluation framework for RAG systems and AI agents with CLI, SDK, and multiple metrics.
 
 ## AI Serving and Inference Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,7 +175,11 @@
 - [agent-inspect](https://github.com/rajudandigam/agent-inspect)：本地 TypeScript Agent 调试与回归测试工具包，可将运行过程转换为执行树、确定性契约、CI 门禁和安全证据包。
 - [brain0](https://github.com/Brain0-ai/brain0)：面向 AI 编写代码的离线决策图，将提交关联到 Agent Prompt 和读取过的上下文，并提供漂移检测、DLP 审计、风险信号和签名溯源。
 - [TokenTelemetry](https://github.com/VasiHemanth/tokentelemetry)：本地仪表盘，用于统一追踪编码 Agent 和自主 Agent 的 Token、成本、工具调用、会话与推理步骤。
-- [Zabbix MCP Server](https://github.com/initMAX/zabbix-mcp-server)：将 Zabbix API 暴露给 AI 助手的 MCP Server，支持多服务器、OAuth 2.1、报表和基础设施调查所需的运维工具。
+- [Agent-Blackbox](https://github.com/TaewoooPark/Agent-Blackbox)：本地优先的编码 Agent 黑盒记录器与上下文效率分析工具，提供可回放的会话地图、成本分析和任务结果信号。
+- [Mira](https://github.com/everruns/mira)：Rust 优先的 Agent 评估框架，面向多轮、工具调用型和长时间运行的 Agent 轨迹，支持运行指标预算和 CI 原生报告。
+- [aws-bench](https://github.com/aws-bench/aws-bench)：在一次性环境中评估编码 Agent 执行真实 AWS 任务能力的基准工具，支持诊断、资源配置和运维任务验证。
+- [claw-swe-bench](https://github.com/opensquilla/claw-swe-bench)：用于在可复现 SWE-bench Issue 修复任务上评估 OpenClaw 风格 Agent Harness 的适配器框架。
+- [OpenAgent Eval](https://github.com/OpenAgentHQ/openagent-eval)：本地优先、框架无关的 RAG 与 AI Agent 评估框架，提供 CLI、SDK 和多种评估指标。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 


### PR DESCRIPTION
## Summary
- Replace the stale Zabbix MCP Server entry in both bilingual READMEs with five production-oriented agent evaluation, replay, and operations benchmarks.

## Projects added
- Agent-Blackbox
- Mira
- aws-bench
- claw-swe-bench
- OpenAgent Eval

## Validation
- Markdown internal-link, duplicate URL/name, and bilingual catalog URL-parity checks passed.
- `git diff --check` passed.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto the latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Verified remote branch SHA matches local HEAD.
- Self-review completed: entries are concise, GitHub-first, category-relevant, and based on live non-archived repositories.

## Risk
- Candidate projects are relatively young; descriptions intentionally stick to capabilities verified from their repository metadata/README. Star counts were used only as discovery signals, not as a quality guarantee.

## Auto-merge intent
- Auto-merge after PR diff/check review when checks are green or absent and the changed scope remains documentation-only.