### PR TITLE
docs: add Google ADK and AssetOpsBench evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval): Open-source RAG evaluation toolkit for measuring retrieval and answer quality without requiring golden answers.
 - [EvalScope](https://github.com/modelscope/evalscope): LLM evaluation framework for capability benchmarks, agent-loop evaluation with recorded traces, inference performance testing, and interactive result analysis.
 - [Kiln](https://github.com/Kiln-AI/kiln): Open-source workbench for building and improving AI systems with collaborative evals, prompt optimization, RAG, agents, synthetic data, and production deployment support.
+- [Google ADK Python](https://github.com/google/adk-python): Code-first Python toolkit for building, evaluating, and deploying production-oriented AI agents with flexible orchestration and tool integration.
+- [AssetOpsBench](https://github.com/IBM/AssetOpsBench): Benchmark and framework for building, orchestrating, and evaluating domain-specific industrial AI agents across reproducible asset-operations scenarios.
 - [Observal](https://github.com/Observal/Observal): Local registry and analytics platform for governing and understanding AI agents, MCP servers, and reusable agent skills.
 - [Agent Prism](https://github.com/evilmartians/agent-prism): React components for visualizing AI agent traces and making multi-step agent execution easier to inspect.
 - [Dash0 Agent Skills](https://github.com/dash0hq/agent-skills): OpenTelemetry skills and reference material for AI coding assistants, covering instrumentation patterns and telemetry quality.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -161,6 +161,8 @@
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval)：开源 RAG 评估工具包，无需预先准备标准答案即可衡量检索和回答质量。
 - [EvalScope](https://github.com/modelscope/evalscope)：LLM 评估框架，支持能力基准测试、带 trace 记录的 Agent Loop 评估、推理性能测试和交互式结果分析。
 - [Kiln](https://github.com/Kiln-AI/kiln)：用于构建和改进 AI 系统的开源工作台，支持协作式评估、Prompt 优化、RAG、Agent、合成数据和生产部署。
+- [Google ADK Python](https://github.com/google/adk-python)：面向代码优先开发的 Python 工具包，用于构建、评估和部署生产导向的 AI Agent，支持灵活编排和工具集成。
+- [AssetOpsBench](https://github.com/IBM/AssetOpsBench)：用于构建、编排和评估行业 AI Agent 的基准与框架，覆盖可复现的工业资产运维场景。
 - [Observal](https://github.com/Observal/Observal)：本地优先的注册与分析平台，用于治理和理解 AI Agent、MCP Server 及可复用 Agent Skill。
 - [Agent Prism](https://github.com/evilmartians/agent-prism)：用于可视化 AI Agent trace 的 React 组件，帮助检查多步骤 Agent 执行过程。
 - [Dash0 Agent Skills](https://github.com/dash0hq/agent-skills)：面向 AI 编码助手的 OpenTelemetry Skill 与参考资料，涵盖插桩模式和遥测质量指南。


### PR DESCRIPTION
## Summary

- Add Google ADK Python and AssetOpsBench to the LLM and Agent Observability catalog.
- Keep English and Simplified Chinese entries semantically aligned and GitHub-first.

## Projects added

- [Google ADK Python](https://github.com/google/adk-python): code-first toolkit for building, evaluating, and deploying AI agents.
- [AssetOpsBench](https://github.com/IBM/AssetOpsBench): benchmark and framework for reproducible industrial AI agent evaluation.

## Validation

- `markdown structural checks ok`
- `git diff --check`
- Changed files limited to `README.md` and `README.zh-CN.md`.
- Verified candidate repositories are active and not archived; star counts used as discovery signals only.
- Rebased onto latest `origin/main`; remote branch SHA matches local HEAD.

## Risk

Documentation-only, low risk. Descriptions are concise and may need refinement as project scope evolves.

## Auto-merge intent

Self-review is required before squash merge. Merge only if the diff remains limited to the two README files and checks are green or absent.
