### PR TITLE
docs: add LiteLLM Agent Control Plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Heym](https://github.com/heymrun/heym): Self-hosted AI workflow platform with visual and prompt-driven workflows, RAG, MCP, human approval, observability, evaluations, and token-cost tracking.
 - [Rapida](https://github.com/rapidaai/voice-ai): Open-source, end-to-end voice AI orchestration platform for real-time agents, integrating audio streaming, STT, TTS, VAD, multi-channel delivery, and observability.
 - [Google Cloud Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack): Production-oriented templates for deploying AI agents to Google Cloud with built-in CI/CD, evaluation, observability, and common enterprise integrations.
+- [LiteLLM Agent Control Plane](https://github.com/LiteLLM-Labs/litellm-agent-control-plane): Self-hosted control plane for running agents across multiple runtimes with unified access, persistent sessions, scheduled jobs, and shared team management.
 
 ## DataOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -363,6 +363,7 @@
 - [Heym](https://github.com/heymrun/heym)：可自托管的 AI 工作流平台，支持可视化和 Prompt 驱动工作流、RAG、MCP、人机审批、可观测性、评估和 Token 成本追踪。
 - [Rapida](https://github.com/rapidaai/voice-ai)：开源端到端语音 AI 编排平台，面向实时 Agent，集成音频流、STT、TTS、VAD、多渠道交付和可观测性。
 - [Google Cloud Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack)：面向生产的 AI Agent 部署模板，可将 Agent 部署到 Google Cloud，并内置 CI/CD、评估、可观测性和常见企业集成。
+- [LiteLLM Agent Control Plane](https://github.com/LiteLLM-Labs/litellm-agent-control-plane)：可自托管的 Agent 控制平面，支持跨多种运行时统一访问、持久化会话、定时任务和团队共享管理。
 
 ## DataOps
 


### PR DESCRIPTION
## Summary
Add a production-oriented AI agent control-plane project to the bilingual awesome-x-ops catalog.

## Projects or content added
- LiteLLM Agent Control Plane — unified access, persistent sessions, scheduled jobs, and team management across agent runtimes.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- English/Chinese parity check passed.
- `git diff --check` passed.
- Diff limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Repository verified via `gh api`: repository is active, 1,170 stars, updated 2026-06-20.

## Risk
Documentation-only, low risk. The project is newer than most entries and its last repository push predates this run; revisit maintenance activity during future curation.

## Auto-merge intent
Auto-merge after self-review and green/absent checks. No failing checks will be bypassed.
