### PR TITLE
Add Darkmoon (autonomous AI pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [OneCLI](https://github.com/onecli/onecli): Open-source credential gateway with built-in vault for giving AI agents access to services without exposing secrets.
 - [Preloop](https://github.com/preloop/preloop): Self-hostable AI agent control plane combining an MCP firewall, model gateway, policy-as-code, human approvals, runtime observability, budgets, and audit trails.
 - [hoop](https://github.com/hoophq/hoop): Open-source layer-7 gateway for engineers and AI agents that masks sensitive data, blocks dangerous infrastructure operations, supports approvals, and records sessions across databases, Kubernetes, SSH, APIs, and MCP.
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon): Open source (GPL-3.0) autonomous AI penetration testing platform covering web, API, Active Directory and Kubernetes.
 - [OpenAnt](https://github.com/knostic/OpenAnt): Open-source LLM-based vulnerability discovery tool for proactively finding verified security flaws in AI systems.
 - [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard): Full-stack AI red teaming platform for scanning AI infrastructure, agents, skills, MCP servers, and LLM jailbreak vulnerabilities.
 - [Cybersecurity AI (CAI)](https://github.com/aliasrobotics/cai): Open-source framework for applying AI agents to cybersecurity research and defensive security workflows.


### PR DESCRIPTION
Thank you for maintaining this list. We would like to propose adding Darkmoon to the Security and Supply Chain section. Darkmoon is an open source (GPL 3.0) autonomous AI penetration testing platform that covers web, API, Active Directory and Kubernetes, and it runs fully self hosted. It sits naturally alongside the other security and auditing tools already listed here. Repository: https://github.com/ASCIT31/Dark-Moon