### PR TITLE
docs: add AI pipeline and agent evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [DB-GPT](https://github.com/eosphoros-ai/DB-GPT): Open-source agentic AI data assistant for building data products, Text-to-SQL, RAG, and multi-agent workflows over private data sources.
 - [BoxLite](https://github.com/boxlite-ai/boxlite): Daemonless micro-VM runtime for AI agents — hardware-isolated, OCI-native execution environments embeddable as a library or deployed as a server.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway): Docker CLI plugin and gateway for securely running, deploying, and managing MCP servers in local or production workflows.
+- [HelixDB](https://github.com/HelixDB/helix-db): Rust-built graph-vector database for knowledge graphs, AI memory, and unified access to relational, document, key-value, and vector data.
+- [RocketRide](https://github.com/rocketride-org/rocketride-server): Open-source AI pipeline builder and runtime with a C++ core, extensible nodes, vector database integrations, and IDE/CLI workflows for production AI systems.
 - [Golf](https://github.com/golf-mcp/golf): Production-ready MCP server framework with authentication, observability, debugging, telemetry, and runtime capabilities for deploying secure agent infrastructure.
 - [Airweave](https://github.com/airweave-ai/airweave): Open-source context retrieval layer that syncs diverse data sources into searchable context for AI agents and applications.
 - [OpenSandbox](https://github.com/opensandbox-group/OpenSandbox): Secure, fast, and extensible sandbox runtime for isolating AI agent code and tool execution.
@@ -533,6 +535,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner): Security scanner for MCP servers that identifies potential threats and security findings before agents depend on their tool integrations.
 - [OctoBus](https://github.com/chaitin/OctoBus): Local single-binary gateway for managing pluggable services and exposing selected capabilities through gRPC, Connect RPC, and MCP.
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard): OWASP project defining inspectable, traceable, and instrumentable observability practices for trustworthy AI agents.
+- [Rogue](https://github.com/qualifire-dev/rogue): AI agent evaluation and red-team platform for regression testing, policy validation, adversarial probing, and security reporting across agent protocols.
 - [SkillHub](https://github.com/iflytek/skillhub): Self-hosted registry for publishing and versioning agent skills with RBAC, audit logs, and Docker or Kubernetes deployment.
 
 ## Platform Engineering

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -304,6 +304,8 @@
 - [DB-GPT](https://github.com/eosphoros-ai/DB-GPT)：开源 Agentic AI 数据助手，支持构建数据产品、Text-to-SQL、RAG 和基于私有数据源的多 Agent 工作流。
 - [BoxLite](https://github.com/boxlite-ai/boxlite)：无守护进程的 AI Agent 微虚拟机运行时，提供硬件隔离、OCI 原生的执行环境，可作为库嵌入或以服务器模式部署。
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway)：Docker CLI 插件与网关，用于在本地或生产工作流中安全运行、部署和管理 MCP Server。
+- [HelixDB](https://github.com/HelixDB/helix-db)：基于 Rust 构建的图-向量数据库，面向知识图谱、AI 记忆，并统一访问关系型、文档、键值和向量数据。
+- [RocketRide](https://github.com/rocketride-org/rocketride-server)：开源 AI 流水线构建器与运行时，采用 C++ 核心，提供可扩展节点、向量数据库集成，以及面向生产 AI 系统的 IDE/CLI 工作流。
 - [Golf](https://github.com/golf-mcp/golf)：面向生产的 MCP Server 框架，提供认证、可观测性、调试、遥测和运行时能力，用于部署安全的 Agent 基础设施。
 - [Airweave](https://github.com/airweave-ai/airweave)：开源上下文检索层，可将多种数据源同步为可搜索上下文，供 AI Agent 和应用使用。
 - [OpenSandbox](https://github.com/opensandbox-group/OpenSandbox)：安全、快速且可扩展的沙箱运行时，用于隔离 AI Agent 代码和工具执行。
@@ -533,6 +535,7 @@
 - [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner)：MCP Server 安全扫描器，可在 Agent 依赖工具集成前识别潜在威胁和安全问题。
 - [OctoBus](https://github.com/chaitin/OctoBus)：本地单二进制网关，用于管理可插拔服务，并通过 gRPC、Connect RPC 和 MCP 暴露选定能力。
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard)：OWASP 项目，为可信 AI Agent 定义可检查、可追踪和可插桩的可观测性实践。
+- [Rogue](https://github.com/qualifire-dev/rogue)：AI Agent 评估与红队平台，支持回归测试、策略校验、对抗性探测和安全报告，覆盖多种 Agent 协议。
 - [SkillHub](https://github.com/iflytek/skillhub)：可自托管的 Agent Skill 注册中心，支持发布与版本管理、RBAC、审计日志，以及 Docker 或 Kubernetes 部署。
 
 ## Platform Engineering 平台工程


### PR DESCRIPTION
## Summary
- Add three production-oriented AI operations projects to the bilingual catalog.

## Projects added
- HelixDB and RocketRide under AI Infrastructure for graph/vector data and AI pipeline runtime capabilities.
- Rogue under Security and Supply Chain for agent evaluation and red-team workflows.

## Validation
- `git diff --check` passed.
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese GitHub entry sets are equal (523 each), including all three additions.
- Verified GitHub repositories are not archived and recorded current star signals: HelixDB 5,687; RocketRide 5,379; Rogue 1,052.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD `19ce2ce73451c785ca677d027df35af53d041c23`.
- Diff is limited to `README.md` and `README.zh-CN.md`.

## Risk
- Descriptions are concise snapshots of fast-moving projects; repository docs remain the source of truth.
- Rogue has a smaller maintenance signal than the two infrastructure projects; it is included because agent evaluation and red-team coverage are strategically relevant.

## Auto-merge intent
- Intended for automatic squash merge after maintainer self-review confirms the bilingual diff is scoped and checks are green or absent.