### PR TITLE
docs: add agent evaluation and inference benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [aws-bench](https://github.com/aws-bench/aws-bench): Benchmark for evaluating coding agents on real AWS tasks in disposable environments, with verifiers for diagnosis, provisioning, and operations.
 - [claw-swe-bench](https://github.com/opensquilla/claw-swe-bench): Adapter framework for evaluating OpenClaw-style agent harnesses on reproducible SWE-bench issue-resolution tasks.
 - [OpenAgent Eval](https://github.com/OpenAgentHQ/openagent-eval): Local-first, framework-agnostic evaluation framework for RAG systems and AI agents with CLI, SDK, and multiple metrics.
+- [LLM Space](https://github.com/deer-flow/llm-space): Local-first desktop workspace for prototyping agents, inspecting harness steps, replaying failures, and evaluating agent performance.
+- [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym): Open framework for evaluating and improving models and agents through configurable environments and evaluation workflows.
 
 ## AI Serving and Inference Operations
 
@@ -202,6 +204,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [KubeRay](https://github.com/ray-project/kuberay): Kubernetes operator and toolkit for deploying and managing Ray clusters and distributed AI workloads.
 - [SGLang](https://github.com/sgl-project/sglang): High-performance serving framework for large language models and multimodal models with efficient attention and structured outputs.
 - [vLLM](https://github.com/vllm-project/vllm): High-throughput and memory-efficient inference and serving engine for LLMs with continuous batching and quantization.
+- [GuideLLM](https://github.com/vllm-project/guidellm): Benchmarking tool for evaluating LLM deployments with real-world latency, throughput, and performance measurements.
 - [Ollama](https://github.com/ollama/ollama): Local-first LLM runner for getting started quickly with models locally, on edge, or in development environments.
 - [llama.cpp](https://github.com/ggml-org/llama.cpp): High-performance C/C++ LLM inference engine with quantization, powering many local and server-side AI backends.
 - [LocalAI](https://github.com/mudler/LocalAI): Self-hosted, OpenAI-compatible local AI API for running LLMs, image generation, and audio models with container-based deployment.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,6 +183,8 @@
 - [aws-bench](https://github.com/aws-bench/aws-bench)：在一次性环境中评估编码 Agent 执行真实 AWS 任务能力的基准工具，支持诊断、资源配置和运维任务验证。
 - [claw-swe-bench](https://github.com/opensquilla/claw-swe-bench)：用于在可复现 SWE-bench Issue 修复任务上评估 OpenClaw 风格 Agent Harness 的适配器框架。
 - [OpenAgent Eval](https://github.com/OpenAgentHQ/openagent-eval)：本地优先、框架无关的 RAG 与 AI Agent 评估框架，提供 CLI、SDK 和多种评估指标。
+- [LLM Space](https://github.com/deer-flow/llm-space)：本地优先的桌面工作台，用于构建 Agent 原型、检查 Harness 每一步、回放失败过程并评估 Agent 性能。
+- [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym)：用于通过可配置环境和评估工作流评估与改进模型及 Agent 的开源框架。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 
@@ -202,6 +204,7 @@
 - [KubeRay](https://github.com/ray-project/kuberay)：Kubernetes Operator 与工具集，用于部署和管理 Ray 集群及分布式 AI 工作负载。
 - [SGLang](https://github.com/sgl-project/sglang)：高性能 LLM 与多模态模型推理服务框架，支持高效注意力机制和结构化输出。
 - [vLLM](https://github.com/vllm-project/vllm)：高吞吐、内存高效的 LLM 推理与服务引擎，支持连续批处理与量化。
+- [GuideLLM](https://github.com/vllm-project/guidellm)：用于评估 LLM 部署的基准测试工具，可测量真实场景下的延迟、吞吐和性能。
 - [Ollama](https://github.com/ollama/ollama)：本地优先的 LLM 运行工具，适合在本地、边缘或开发环境中快速上手模型推理。
 - [llama.cpp](https://github.com/ggml-org/llama.cpp)：高性能 C/C++ LLM 推理引擎，支持量化，为众多本地和服务端 AI 后端提供基础能力。
 - [LocalAI](https://github.com/mudler/LocalAI)：自托管的 OpenAI 兼容本地 AI API，支持基于容器部署运行 LLM、图像生成和音频模型。


### PR DESCRIPTION
## Summary
- Add two production-oriented AI evaluation tools to the LLM and Agent Observability section.
- Add GuideLLM to AI Serving and Inference Operations for deployment benchmarking.
- Keep English and Simplified Chinese entries aligned.

## Projects added
- LLM Space — local-first agent prototyping, step inspection, failure replay, and evaluation.
- NeMo Gym — configurable environments for evaluating and improving models and agents.
- GuideLLM — real-world LLM deployment latency, throughput, and performance benchmarking.

## Validation
- `markdown structural checks ok`
- English/Chinese GitHub entry sets: 526/526, equal
- `git diff --check` passed
- Diff limited to `README.md` and `README.zh-CN.md`
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD
- Remote branch SHA verified equal to local HEAD
- PR self-review: clean; bilingual entries are semantically aligned and URLs are canonical GitHub repositories

## Risk
Documentation-only change. Main risk is project maturity or positioning changing over time; no runtime or dependency impact.

## Auto-merge intent
Auto-merge after self-review and checks are green or absent, using squash merge and deleting the branch.