### PR TITLE
docs: add AWS agent evaluation to observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [OpenAgent Eval](https://github.com/OpenAgentHQ/openagent-eval): Local-first, framework-agnostic evaluation framework for RAG systems and AI agents with CLI, SDK, and multiple metrics.
 - [LLM Space](https://github.com/deer-flow/llm-space): Local-first desktop workspace for prototyping agents, inspecting harness steps, replaying failures, and evaluating agent performance.
 - [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym): Open framework for evaluating and improving models and agents through configurable environments and evaluation workflows.
+- [Agent Evaluation](https://github.com/awslabs/agent-evaluation): Generative AI evaluation framework for concurrent multi-turn virtual-agent testing, custom targets, hooks, and CI/CD integration.
 
 ## AI Serving and Inference Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -185,6 +185,7 @@
 - [OpenAgent Eval](https://github.com/OpenAgentHQ/openagent-eval)：本地优先、框架无关的 RAG 与 AI Agent 评估框架，提供 CLI、SDK 和多种评估指标。
 - [LLM Space](https://github.com/deer-flow/llm-space)：本地优先的桌面工作台，用于构建 Agent 原型、检查 Harness 每一步、回放失败过程并评估 Agent 性能。
 - [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym)：用于通过可配置环境和评估工作流评估与改进模型及 Agent 的开源框架。
+- [Agent Evaluation](https://github.com/awslabs/agent-evaluation)：生成式 AI 评估框架，支持并发多轮虚拟 Agent 测试、自定义目标、Hook 以及 CI/CD 集成。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 


### PR DESCRIPTION
## Summary
- Add AWS Labs Agent Evaluation to the LLM and Agent Observability section.
- Keep English and Simplified Chinese entries semantically aligned.

## Projects added
- [Agent Evaluation](https://github.com/awslabs/agent-evaluation): concurrent multi-turn virtual-agent testing, custom targets, hooks, and CI/CD integration.

## Validation
- Markdown structural checks: passed.
- Duplicate URL and entry-name checks: passed.
- Bilingual GitHub entry parity: passed (526 entries in each README).
- `git diff --check`: passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.
- Self-review: changed files are limited to `README.md` and `README.zh-CN.md`; descriptions are concise and equivalent.

## Risk
- Documentation-only change; low operational risk. The candidate is production-oriented but its repository activity is less recent than some alternatives, so adoption/maintenance should be revisited during future curation.

## Auto-merge intent
- Auto-merge after self-review and checks are green or absent.
