### PR TITLE
docs: add Litefuse to LLM observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 - [LiteLLM](https://github.com/BerriAI/litellm): OpenAI-compatible LLM gateway with routing, budgets, logging, and provider abstraction.
 - [Langfuse](https://github.com/langfuse/langfuse): Open-source LLM engineering platform for traces, prompt management, evaluations, and metrics.
+- [Litefuse](https://github.com/litefuse/litefuse): Open-source LLM engineering platform for collaboratively developing, monitoring, evaluating, and debugging AI applications with self-hosted deployment.
 - [DeepEval](https://github.com/confident-ai/deepeval): LLM evaluation framework for testing RAG, agents, and model outputs in CI or production workflows.
 - [Ragas](https://github.com/explodinggradients/ragas): Evaluation framework for RAG pipelines and LLM applications.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix): Open-source observability and evaluation platform for LLM, RAG, and ML systems.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,6 +56,7 @@
 
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。
 - [Langfuse](https://github.com/langfuse/langfuse)：开源 LLM 工程平台，支持链路追踪、Prompt 管理、评估和指标分析。
+- [Litefuse](https://github.com/litefuse/litefuse)：开源 LLM 工程平台，支持协作开发、监控、评估和调试 AI 应用，并可自托管部署。
 - [DeepEval](https://github.com/confident-ai/deepeval)：LLM 评估框架，适合在 CI 或生产流程中测试 RAG、Agent 和模型输出。
 - [Ragas](https://github.com/explodinggradients/ragas)：面向 RAG 流水线和 LLM 应用的评估框架。
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix)：面向 LLM、RAG 和机器学习系统的开源可观测与评估平台。


### PR DESCRIPTION
## Summary
- Add Litefuse to the LLM and Agent Observability section in both README language variants.
- Describe its open-source development, monitoring, evaluation, debugging, and self-hosting capabilities.

## Projects added
- Litefuse — https://github.com/litefuse/litefuse

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese entries are present with matching project URL and equivalent meaning.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Diff is limited to `README.md` and `README.zh-CN.md`.

## Risk
- Documentation-only change; low runtime risk. Litefuse is actively updated but its GitHub API license is reported as `NOASSERTION`; maintainers may want to confirm licensing before merging.

## Auto-merge intent
- Requesting maintainer review; do not auto-merge.