### PR TITLE
docs: add AI SRE incident response tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [Metaflow](https://github.com/Netflix/metaflow): Human-centric framework for developing, versioning, scaling, and deploying production AI/ML systems from prototypes to reliable workflows.
 - [Chaterm](https://github.com/chaterm/Chaterm): Open-source AI terminal for cloud and infrastructure management, enabling natural-language deployment, troubleshooting, and automation across SSH, Kubernetes, and cloud services.
 - [Versus Incident](https://github.com/VersusControl/versus-incident): Self-hosted AI SRE agent that learns normal system behavior and routes novel or unexpected incidents to chat and on-call platforms.
+- [Flawless](https://github.com/William-Lu-stack/Flawless): AI-native SRE control plane for Kubernetes and cloud infrastructure, connecting evidence, human approval, controlled remediation, rollback, and recovery verification in an auditable loop.
+- [Nudgebee](https://github.com/nudgebee/nudgebee): Open-source SRE copilot for Kubernetes and major clouds, combining observability, FinOps, runbook automation, incident response, and ChatOps workflows.
 
 ## AI Infrastructure
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -256,6 +256,8 @@
 - [Metaflow](https://github.com/Netflix/metaflow)：面向人的 AI/ML 系统开发框架，支持从原型到生产工作流的开发、版本管理、扩展和部署。
 - [Chaterm](https://github.com/chaterm/Chaterm)：开源 AI 终端，面向云和基础设施管理，支持通过自然语言跨 SSH、Kubernetes 和云服务进行部署、排障和自动化。
 - [Versus Incident](https://github.com/VersusControl/versus-incident)：可自托管的 AI SRE Agent，学习系统的正常行为，并将新出现或异常的事件路由到聊天和值班平台。
+- [Flawless](https://github.com/William-Lu-stack/Flawless)：面向 Kubernetes 和云基础设施的 AI 原生 SRE 控制平面，将证据收集、人机审批、受控修复、回滚和恢复验证连接成可审计闭环。
+- [Nudgebee](https://github.com/nudgebee/nudgebee)：面向 Kubernetes 和主流云平台的开源 SRE Copilot，整合可观测性、FinOps、Runbook 自动化、事件响应和 ChatOps 工作流。
 
 ## AI 基础设施
 


### PR DESCRIPTION
## Summary
- Add two production-oriented AI SRE incident-response tools to the AIOps section.
- Keep English and Simplified Chinese README entries aligned.

## Projects added
- Flawless — auditable Kubernetes/cloud SRE control plane with approvals, remediation, rollback, and recovery verification.
- Nudgebee — SRE copilot combining observability, FinOps, runbook automation, incident response, and ChatOps.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English/Chinese catalog entry counts match: 545 / 545; both new projects present in both files.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Changed files restricted to `README.md` and `README.zh-CN.md`.
- Remote branch SHA verified against local HEAD.

## Risk
- Documentation-only change. Project maturity and licensing should be revisited during future curation; Flawless is PolyForm Noncommercial and Nudgebee is BSL 1.1.

## Auto-merge intent
- Request automatic squash merge after self-review and green/absent checks.