### PR TITLE
docs: clarify LLM observability selection guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This project aims to become a practical open-source map for modern X-Ops. Contri
 
 Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent applications in production.
 
+**Selection guidance:** Prefer tools that connect traces to prompts, model versions, evaluations, and cost or latency signals; use gateway, security, and serving tools in their dedicated sections when observability is not their primary operational purpose.
+
 - [LiteLLM](https://github.com/BerriAI/litellm): OpenAI-compatible LLM gateway with routing, budgets, logging, and provider abstraction.
 - [Langfuse](https://github.com/langfuse/langfuse): Open-source LLM engineering platform for traces, prompt management, evaluations, and metrics.
 - [Litefuse](https://github.com/litefuse/litefuse): Open-source LLM engineering platform for collaboratively developing, monitoring, evaluating, and debugging AI applications with self-hosted deployment.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,6 +54,8 @@
 
 用于追踪、评估、调试和生产化运行 LLM、RAG 与 Agent 应用的工具。
 
+**选择建议：** 优先选择能将 trace 与 Prompt、模型版本、评估结果及成本或延迟信号关联起来的工具；如果工具的主要职责不是可观测性，应放入专门的网关、安全或推理服务分类。
+
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。
 - [Langfuse](https://github.com/langfuse/langfuse)：开源 LLM 工程平台，支持链路追踪、Prompt 管理、评估和指标分析。
 - [Litefuse](https://github.com/litefuse/litefuse)：开源 LLM 工程平台，支持协作开发、监控、评估和调试 AI 应用，并可自托管部署。


### PR DESCRIPTION
## Summary

- Add concise selection guidance to the LLM and Agent Observability section.
- Keep the guidance synchronized in English and Simplified Chinese.

## Content added

- Observability tools should connect traces with prompts, model versions, evaluations, and cost or latency signals.
- Gateway, security, and serving tools should remain in their dedicated sections when observability is not their primary purpose.

## Validation

- `markdown structural checks ok`
- `git diff --check`
- Changed files are limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Self-review completed; bilingual meaning and formatting are aligned.

## Risk

Low: documentation-only guidance; no project links or runtime code changed.

## Auto-merge intent

Auto-merge after self-review and green or absent checks.
