### PR TITLE
docs: add Pi agent observability tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [AURA](https://github.com/mezmo/aura): Production-oriented harness for safe AI SRE agents, with guardrails, state management, authentication, streaming, and operational tool integrations.
 - [ongrid](https://github.com/ongridio/ongrid): Ops AI agent that investigates infrastructure root causes and performs guarded remediation through common team-chat interfaces.
 - [Agents Observe](https://github.com/simple10/agents-observe): Real-time observability dashboard for Claude Code and Codex agents with session replay, filtering, and token usage statistics.
+- [Pi Agent Observability](https://github.com/disler/pi-agent-observability): Local observability stack for the Pi coding agent, streaming turns, tool calls, model changes, and token-cost telemetry into a dashboard for replay and comparison.
 - [Axon](https://github.com/langchain-tracer/Axon): OpenTelemetry-native LLM observability CLI for viewing LLM and agent traces in real time.
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval): Open-source RAG evaluation toolkit for measuring retrieval and answer quality without requiring golden answers.
 - [EvalScope](https://github.com/modelscope/evalscope): LLM evaluation framework for capability benchmarks, agent-loop evaluation with recorded traces, inference performance testing, and interactive result analysis.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -162,6 +162,7 @@
 - [AURA](https://github.com/mezmo/aura)：面向生产的安全 AI SRE Agent 驾驭框架，提供护栏、状态管理、身份认证、流式执行和运维工具集成。
 - [ongrid](https://github.com/ongridio/ongrid)：运维 AI Agent，可通过常见团队聊天界面调查基础设施根因并执行带护栏的修复。
 - [Agents Observe](https://github.com/simple10/agents-observe)：Claude Code 和 Codex Agent 的实时可观测仪表盘，支持会话回放、过滤和 Token 用量统计。
+- [Pi Agent Observability](https://github.com/disler/pi-agent-observability)：面向 Pi 编码 Agent 的本地可观测性栈，将每轮执行、工具调用、模型变更及 Token 成本遥测流入仪表盘，支持回放和对比。
 - [Axon](https://github.com/langchain-tracer/Axon)：基于 OpenTelemetry 的 LLM 可观测性 CLI，可实时查看 LLM 和 Agent 链路。
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval)：开源 RAG 评估工具包，无需预先准备标准答案即可衡量检索和回答质量。
 - [EvalScope](https://github.com/modelscope/evalscope)：LLM 评估框架，支持能力基准测试、带 trace 记录的 Agent Loop 评估、推理性能测试和交互式结果分析。


### PR DESCRIPTION
## Summary

- Add Pi Agent Observability to the LLM and Agent Observability section.
- Keep English and Simplified Chinese entries semantically aligned.

## Projects added

- [Pi Agent Observability](https://github.com/disler/pi-agent-observability): local observability stack for the Pi coding agent, covering turns, tool calls, model changes, token-cost telemetry, replay, and comparison.

## Validation

- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- English and Chinese README URL sets match.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.
- PR self-review: changed files are limited to `README.md` and `README.zh-CN.md`; bilingual entries are aligned.

## Risk

Documentation-only change. The project is active and not archived; GitHub API reported 131 stars and a recent repository update. Star counts are discovery signals, not quality guarantees.

## Auto-merge intent

Auto-merge after self-review and checks are green or absent, using squash merge and remote branch deletion.
