### PR TITLE
docs: add Agentset to LLM knowledge tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 
 Open-source platforms for building, managing, and querying LLM-powered knowledge bases from unstructured documents.
 
+- [Agentset](https://github.com/agentset-ai/agentset): Open-source platform for building, evaluating, and shipping production-ready RAG and agentic applications with ingestion, vector indexing, citations, hosting, and developer APIs.
 - [RAGFlow](https://github.com/infiniflow/ragflow): Leading open-source RAG engine that combines deep document understanding, knowledge base management, and agent capabilities for enterprise knowledge workflows.
 - [FastGPT](https://github.com/labring/FastGPT): Knowledge-based LLM application platform with out-of-the-box data processing, model invocation, RAG, and visual workflow orchestration.
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm): Local-first document chat and agent platform that turns any document into a context-aware LLM knowledge base.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,6 +331,7 @@
 
 用于从非结构化文档构建、管理和查询 LLM 知识库的开源平台。
 
+- [Agentset](https://github.com/agentset-ai/agentset)：用于构建、评估和交付生产级 RAG 与 Agent 应用的开源平台，提供数据摄取、向量索引、引用、托管和开发者 API。
 - [RAGFlow](https://github.com/infiniflow/ragflow)：领先的开源 RAG 引擎，融合深度文档理解、知识库管理和 Agent 能力，适合企业知识工作流。
 - [FastGPT](https://github.com/labring/FastGPT)：基于 LLM 的知识库应用平台，提供开箱即用的数据处理、模型调用、RAG 和可视化工作流编排。
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)：本地优先的文档对话和 Agent 平台，可将任意文档转化为上下文感知的 LLM 知识库。


### PR DESCRIPTION
## Summary
- Add Agentset to the LLM Knowledge section in both README language variants.
- Describe its production-oriented RAG and agent application workflow concisely.

## Projects added
- Agentset — https://github.com/agentset-ai/agentset

## Validation
- Verified the repository is active, non-archived, MIT-licensed, and had 2,039 GitHub stars at discovery time.
- Confirmed the English and Simplified Chinese entries are present and semantically aligned.
- Ran Markdown internal-link, duplicate URL/name, bilingual parity, and `git diff --check` validation.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Changed files are limited to `README.md` and `README.zh-CN.md`.

## Risk
- Documentation-only, low risk. Project metadata and star count can change after this run.

## Auto-merge intent
- Request automatic squash merge after PR self-review and green or absent checks. Do not bypass failing checks.
