### PR TITLE
docs: add CodeInspectus to AI security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Toolkit for policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous AI agents.
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector): Security scanner for AI agent skills that detects vulnerabilities, malicious patterns, and other security risks.
 - [Agent Scan](https://github.com/snyk/agent-scan): Security scanner for AI agents, MCP servers, and agent skills.
+- [CodeInspectus](https://github.com/Synvoya/codeinspectus): Local-first MCP server and CLI that combines SAST, secret, dependency, and AI-code-specific checks into a scan-fix-rescan workflow for AI-generated applications.
 - [DefenseClaw](https://github.com/cisco-ai-defense/defenseclaw): Open-source governance toolkit for agentic AI security, helping assess and control risks in autonomous AI systems.
 - [Apache Casbin Gateway](https://github.com/apache/casbin-gateway): Apache-licensed AI and MCP security gateway for HTTP access control, policy enforcement, and web application firewall integration.
 - [Semia](https://github.com/berabuddies/Semia): Security audit tool for AI agent skills that checks skill packages for suspicious behavior and security risks.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -536,6 +536,7 @@
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)：用于自主 AI Agent 的策略执行、零信任身份、执行沙箱和可靠性工程工具包。
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector)：AI Agent Skill 安全扫描器，用于检测漏洞、恶意模式和其他安全风险。
 - [Agent Scan](https://github.com/snyk/agent-scan)：面向 AI Agent、MCP Server 和 Agent Skill 的安全扫描器。
+- [CodeInspectus](https://github.com/Synvoya/codeinspectus)：本地优先的 MCP Server 与 CLI，将 SAST、Secret、依赖和 AI 代码专项检查整合为面向 AI 生成应用的扫描、修复、复扫工作流。
 - [DefenseClaw](https://github.com/cisco-ai-defense/defenseclaw)：面向 Agentic AI 安全的开源治理工具包，用于评估和控制自主 AI 系统中的风险。
 - [Apache Casbin Gateway](https://github.com/apache/casbin-gateway)：基于 Apache 许可证的 AI 与 MCP 安全网关，支持 HTTP 访问控制、策略执行和 Web 应用防火墙集成。
 - [Semia](https://github.com/berabuddies/Semia)：AI Agent Skill 安全审计工具，用于检查 Skill 包中的可疑行为和安全风险。


### PR DESCRIPTION
## Summary

- Add CodeInspectus to the AI security and supply-chain section in both README language variants.
- Describe its local-first MCP/CLI scan-fix-rescan workflow and combined SAST, secret, dependency, and AI-code-specific checks.

## Projects added

- CodeInspectus — https://github.com/Synvoya/codeinspectus (36 GitHub stars at curation time; active, non-archived MIT project; last push 2026-07-30).

## Validation

- `markdown structural checks ok`
- English and Simplified Chinese GitHub entry URL sets match: 544 entries.
- `git diff --check` passed.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD: `0975abf8e175db9c1edf52c3a621bca68b9ab819`.
- Self-review: bilingual entries are semantically aligned, category fit is clear, and no duplicate name/URL was found.

## Risk

Low: documentation-only, one new project entry, no runtime or generated files changed. Project maturity and claims should be revisited during future curation runs.

## Auto-merge intent

Auto-merge after the required self-review and checks are green or absent. Do not bypass failing checks.