### PR TITLE
docs: add Opik MCP and Supergateway to AI Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [abtop](https://github.com/graykode/abtop): htop-style terminal monitor for AI coding agent sessions, tokens, context windows, rate limits, and ports.
 - [agenttrace](https://github.com/luoyuctl/agenttrace): Local-first TUI for inspecting AI coding agent cost, tokens, latency, failures, and reports.
 - [OpenTelemetry MCP Server](https://github.com/traceloop/opentelemetry-mcp-server): Unified MCP server for querying OpenTelemetry traces across Jaeger, Tempo, Traceloop, and other backends so AI agents can investigate distributed systems.
+- [Opik MCP](https://github.com/comet-ml/opik-mcp): MCP server for reading Opik traces, logging evaluation scores, and managing prompts from AI coding clients.
 - [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay): Multi-language agent runtime and middleware library for managing execution scopes, lifecycle events, and tool or LLM call telemetry.
 - [Kitaru](https://github.com/zenml-io/kitaru): Production AI agent recording and replay toolkit for analyzing runs and improving agent behavior.
 - [ax](https://github.com/Necmttn/ax): Local-first telemetry and memory graph for AI coding agents, covering costs, tools, skills, sessions, and OTLP events.
@@ -111,6 +112,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Trench](https://github.com/FrigadeHQ/trench): Open-source analytics infrastructure for building production event tracking, LLM/RAG observability, and analytics products on ClickHouse and Kafka.
 - [Kubeshark](https://github.com/kubeshark/kubeshark): eBPF-powered Kubernetes network observability with L4/L7 traffic context, TLS visibility, and an MCP interface for AI-assisted investigation.
 - [MCP Gateway](https://github.com/IBM/mcp-context-forge): AI gateway, registry, and proxy for MCP, A2A, and API tools with centralized discovery, guardrails, and management.
+- [Supergateway](https://github.com/supercorp-ai/supergateway): Lightweight bridge that runs MCP stdio servers over SSE and converts SSE connections back to stdio for interoperable deployments.
 - [NVIDIA NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails): Toolkit for adding programmable safety, dialog, and policy guardrails to LLM-based conversational systems.
 - [Llama Guard](https://github.com/meta-llama/PurpleLlama): Meta's open trust and safety toolkit for evaluating and filtering LLM inputs, outputs, and model risks.
 - [LLM Guard](https://github.com/protectai/llm-guard): Security toolkit for sanitizing LLM inputs and outputs, detecting prompt injection, blocking harmful content, and reducing data leakage.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,6 +79,7 @@
 - [abtop](https://github.com/graykode/abtop)：类似 htop 的终端监控工具，用于查看 AI 编码 Agent 会话、Token、上下文窗口、速率限制和端口。
 - [agenttrace](https://github.com/luoyuctl/agenttrace)：本地优先的 TUI，用于检查 AI 编码 Agent 的成本、Token、延迟、失败和报告。
 - [OpenTelemetry MCP Server](https://github.com/traceloop/opentelemetry-mcp-server)：统一的 MCP Server，可查询 Jaeger、Tempo、Traceloop 等后端的 OpenTelemetry 链路，让 AI Agent 能够调查分布式系统。
+- [Opik MCP](https://github.com/comet-ml/opik-mcp)：面向 AI 编码客户端的 MCP Server，可读取 Opik trace、记录评估分数并管理 Prompt。
 - [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay)：多语言 Agent 运行时与中间件库，用于管理执行作用域、生命周期事件以及工具或 LLM 调用遥测。
 - [Kitaru](https://github.com/zenml-io/kitaru)：面向生产环境的 AI Agent 录制与回放工具，用于分析运行过程并改进 Agent 行为。
 - [ax](https://github.com/Necmttn/ax)：面向 AI 编码 Agent 的本地优先遥测与记忆图，覆盖成本、工具、技能、会话和 OTLP 事件。
@@ -111,6 +112,7 @@
 - [Trench](https://github.com/FrigadeHQ/trench)：基于 ClickHouse 和 Kafka 的开源分析基础设施，可用于构建生产事件追踪、LLM/RAG 可观测性和分析产品。
 - [Kubeshark](https://github.com/kubeshark/kubeshark)：基于 eBPF 的 Kubernetes 网络可观测工具，提供 L4/L7 流量上下文、TLS 可见性，以及供 AI 辅助调查使用的 MCP 接口。
 - [MCP Gateway](https://github.com/IBM/mcp-context-forge)：面向 MCP、A2A 和 API 工具的 AI 网关、注册表与代理，支持集中发现、护栏和管理。
+- [Supergateway](https://github.com/supercorp-ai/supergateway)：轻量级桥接工具，可将 MCP stdio Server 通过 SSE 暴露，也能将 SSE 连接转换回 stdio，便于不同部署方式互通。
 - [NVIDIA NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails)：用于为基于 LLM 的对话系统加入可编程安全、对话和策略护栏的工具包。
 - [Llama Guard](https://github.com/meta-llama/PurpleLlama)：Meta 开源的信任与安全工具集，用于评估和过滤 LLM 输入、输出与模型风险。
 - [LLM Guard](https://github.com/protectai/llm-guard)：LLM 交互安全工具包，用于清洗输入输出、检测 Prompt 注入、拦截有害内容并降低数据泄露风险。


### PR DESCRIPTION
## Summary

- Add Opik MCP to the LLM and Agent Observability section in both README variants.
- Add Supergateway to the AI gateway/MCP operations entries in both README variants.

## Projects added

- [Opik MCP](https://github.com/comet-ml/opik-mcp): MCP access to Opik traces, evaluation scores, and prompts.
- [Supergateway](https://github.com/supercorp-ai/supergateway): stdio/SSE bridging for MCP server deployments.

## Validation

- Markdown internal-link, duplicate URL, and duplicate entry-name checks passed.
- `git diff --check` passed.
- English and Simplified Chinese entries were added in semantic parity.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- GitHub repository checks: both projects are non-archived; Opik MCP is Apache-2.0 with 216 stars, and Supergateway is MIT with 2,790 stars at curation time.

## Risk

Documentation-only change. Descriptions are intentionally concise; project capabilities and popularity can change over time.

## Auto-merge intent

Auto-merge is allowed after self-review and only if checks are green or absent. No failing checks will be bypassed.
