### PR TITLE
docs: add AI agent security evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [AgentShield](https://github.com/affaan-m/agentshield): AI agent security scanner for detecting vulnerabilities in agent configurations, MCP servers, and tool permissions via CLI or GitHub Action.
 - [Crust](https://github.com/BakeLens/crust): Local AI-agent security gateway that intercepts tool calls and MCP/ACP traffic to block dangerous actions, scan secrets, and enforce runtime rules.
 - [Adrian](https://github.com/secureagentics/Adrian): Open-source runtime AI agent security tool that monitors and controls AI agents in real time, catching malicious tool use, prompt injection, and policy drift before the agent acts.
+- [Doberman](https://github.com/fu351/Doberman-Core): Runtime guardrails and adaptive authorization for AI coding agents, with MCP or host-hook enforcement, approvals, audit logs, and fail-closed policy decisions.
+- [Agent3σ-Canary](https://github.com/antgroup/Agent3Sigma-Canary): Sandboxed framework for evaluating AI agent security in realistic tool-using workflows, with trajectory-based scoring across safety, awareness, and task utility.
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Toolkit for policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous AI agents.
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector): Security scanner for AI agent skills that detects vulnerabilities, malicious patterns, and other security risks.
 - [Agent Scan](https://github.com/snyk/agent-scan): Security scanner for AI agents, MCP servers, and agent skills.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -539,6 +539,8 @@
 - [AgentShield](https://github.com/affaan-m/agentshield)：AI Agent 安全扫描器，通过 CLI 或 GitHub Action 检测 Agent 配置、MCP Server 和工具权限中的漏洞。
 - [Crust](https://github.com/BakeLens/crust)：本地 AI Agent 安全网关，可拦截工具调用及 MCP/ACP 流量，阻止危险操作、扫描 Secret 并执行运行时规则。
 - [Adrian](https://github.com/secureagentics/Adrian)：开源 AI Agent 运行时安全工具，实时监控和控制 AI Agent，在 Agent 执行动作前拦截恶意工具调用、Prompt 注入和策略偏移。
+- [Doberman](https://github.com/fu351/Doberman-Core)：面向 AI 编码 Agent 的运行时护栏与自适应授权工具，通过 MCP 或主机 Hook 在执行前实施策略，提供审批、审计日志和默认拒绝机制。
+- [Agent3σ-Canary](https://github.com/antgroup/Agent3Sigma-Canary)：在沙箱化真实工具工作流中评估 AI Agent 安全性的框架，基于完整执行轨迹从安全结果、安全意识和任务效用等维度评分。
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)：用于自主 AI Agent 的策略执行、零信任身份、执行沙箱和可靠性工程工具包。
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector)：AI Agent Skill 安全扫描器，用于检测漏洞、恶意模式和其他安全风险。
 - [Agent Scan](https://github.com/snyk/agent-scan)：面向 AI Agent、MCP Server 和 Agent Skill 的安全扫描器。


### PR DESCRIPTION
## Summary
- Add two production-oriented AI agent security entries to both README language variants.

## Projects added
- Doberman: runtime guardrails and adaptive authorization.
- Agent3σ-Canary: sandboxed, trajectory-based agent security evaluation.

## Validation
- Markdown structural checks passed.
- Bilingual URL parity and new-entry checks passed.
- `git diff --check` passed.
- Rebasing onto latest `origin/main` passed; base is an ancestor of HEAD.
- Self-review: changed files are limited to the two expected README files and descriptions are semantically aligned.

## Risk
- Documentation-only change; project maturity and positioning should be revisited as upstreams evolve.

## Auto-merge intent
- Merge automatically after self-review if checks are green or absent.