### PR TITLE
docs: add AI data and security operations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox): Kubernetes API and controller for managing isolated, stateful, singleton workloads such as AI agent runtimes.
 - [AgentOS](https://github.com/rivet-dev/agentos): Library that gives AI agents an operating-system-like runtime in an existing backend using WebAssembly and V8 isolates.
 - [Cua](https://github.com/trycua/cua): Open-source computer-use infrastructure with cross-platform drivers, fleets, and benchmarks for agent training, evaluation, and data generation.
+- [Apache Doris](https://github.com/apache/doris): Real-time analytics and hybrid-search database for AI agents and operational data workloads.
 
 ## LLM Knowledge
 
@@ -350,6 +351,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Mem0](https://github.com/mem0ai/mem0): Universal memory layer for AI agents with multi-level memory, entity linking, and temporal reasoning for personalized interactions.
 - [Zep](https://github.com/getzep/zep): Open-source memory layer for AI agents providing long-term recall, user facts, and knowledge graph capabilities for persistent agent memory.
 - [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG): Open-source framework for RAG evaluation and optimization with AutoML-style automation for pipeline tuning.
+- [MemoryBench](https://github.com/supermemoryai/memorybench): Unified benchmark for evaluating conversational memory and RAG across multiple datasets.
 - [MemPalace](https://github.com/MemPalace/mempalace): Open-source AI memory system with best-in-class benchmarks, providing persistent knowledge storage for AI agents and LLM applications.
 - [LightRAG](https://github.com/HKUDS/LightRAG): Simple and fast RAG framework with graph-based retrieval, supporting incremental updates and efficient knowledge graph construction.
 - [Kotaemon](https://github.com/Cinnamon/kotaemon): Open-source RAG-based document QA tool with multi-model support and a customizable UI for chatting with documents.
@@ -535,6 +537,8 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Octelium](https://github.com/octelium/octelium): Self-hosted zero-trust access platform that also operates as an API, AI/LLM, MCP, Kubernetes, and container application gateway.
 - [OpenAnt](https://github.com/knostic/OpenAnt): Open-source LLM-based vulnerability discovery tool for proactively finding verified security flaws in AI systems.
 - [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard): Full-stack AI red teaming platform for scanning AI infrastructure, agents, skills, MCP servers, and LLM jailbreak vulnerabilities.
+- [Anthropic Cybersecurity Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills): Apache-2.0 collection of structured cybersecurity skills for AI agents, mapped to ATT&CK, NIST CSF, MITRE ATLAS, D3FEND, and AI RMF.
+- [Kubernetes AI-BOM](https://github.com/GoogleCloudPlatform/k8s-aibom): Kubernetes controller that generates CycloneDX ML-BOM documents for AI workloads with traceable runtime evidence.
 - [Cybersecurity AI (CAI)](https://github.com/aliasrobotics/cai): Open-source framework for applying AI agents to cybersecurity research and defensive security workflows.
 - [AgentShield](https://github.com/affaan-m/agentshield): AI agent security scanner for detecting vulnerabilities in agent configurations, MCP servers, and tool permissions via CLI or GitHub Action.
 - [Crust](https://github.com/BakeLens/crust): Local AI-agent security gateway that intercepts tool calls and MCP/ACP traffic to block dangerous actions, scan secrets, and enforce runtime rules.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -335,6 +335,7 @@
 - [Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox)：用于管理隔离、有状态、单例工作负载的 Kubernetes API 与控制器，适合 AI Agent 运行时。
 - [AgentOS](https://github.com/rivet-dev/agentos)：基于 WebAssembly 和 V8 isolate 的库，可在现有后端中为 AI Agent 提供类似操作系统的运行时。
 - [Cua](https://github.com/trycua/cua)：开源 computer-use 基础设施，提供跨平台驱动、设备集群和基准测试，用于 Agent 训练、评估和数据生成。
+- [Apache Doris](https://github.com/apache/doris)：面向 AI Agent 和运维数据工作负载的实时分析与混合搜索数据库。
 
 ## LLM 知识库
 
@@ -350,6 +351,7 @@
 - [Mem0](https://github.com/mem0ai/mem0)：面向 AI Agent 的通用记忆层，支持多级记忆、实体链接和时间推理，实现个性化交互。
 - [Zep](https://github.com/getzep/zep)：开源 AI Agent 记忆层，提供长期记忆召回、用户事实和知识图谱能力，实现持久的 Agent 记忆。
 - [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG)：开源 RAG 评估与优化框架，通过 AutoML 风格自动化进行流水线调优。
+- [MemoryBench](https://github.com/supermemoryai/memorybench)：用于在多个数据集上评估对话记忆和 RAG 能力的统一基准测试工具。
 - [MemPalace](https://github.com/MemPalace/mempalace)：开源 AI 记忆系统，提供基准测试最优的持久化知识存储能力，适用于 AI Agent 和 LLM 应用。
 - [LightRAG](https://github.com/HKUDS/LightRAG)：简洁高效的 RAG 框架，基于图谱检索，支持增量更新和高效知识图谱构建。
 - [Kotaemon](https://github.com/Cinnamon/kotaemon)：开源的 RAG 文档问答工具，支持多模型接入和可定制 UI，实现与文档的智能对话交互。
@@ -535,6 +537,8 @@
 - [Octelium](https://github.com/octelium/octelium)：可自托管的零信任访问平台，同时可作为 API、AI/LLM、MCP、Kubernetes 和容器应用网关。
 - [OpenAnt](https://github.com/knostic/OpenAnt)：基于 LLM 的开源漏洞发现工具，可主动发现 AI 系统中经过验证的安全漏洞。
 - [AI-Infra-Guard](https://github.com/Tencent/AI-Infra-Guard)：全栈 AI 红队平台，用于扫描 AI 基础设施、Agent、技能、MCP Server 和 LLM 越狱漏洞。
+- [Anthropic Cybersecurity Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills)：Apache-2.0 许可的结构化 AI Agent 网络安全 Skill 集合，映射 MITRE ATT&CK、NIST CSF、MITRE ATLAS、D3FEND 和 AI RMF。
+- [Kubernetes AI-BOM](https://github.com/GoogleCloudPlatform/k8s-aibom)：Kubernetes 控制器，可为 AI 工作负载生成 CycloneDX ML-BOM，并提供可追溯的运行时证据。
 - [Cybersecurity AI (CAI)](https://github.com/aliasrobotics/cai)：开源框架，用于将 AI Agent 应用于网络安全研究和防御性安全工作流。
 - [AgentShield](https://github.com/affaan-m/agentshield)：AI Agent 安全扫描器，通过 CLI 或 GitHub Action 检测 Agent 配置、MCP Server 和工具权限中的漏洞。
 - [Crust](https://github.com/BakeLens/crust)：本地 AI Agent 安全网关，可拦截工具调用及 MCP/ACP 流量，阻止危险操作、扫描 Secret 并执行运行时规则。


### PR DESCRIPTION
## Summary
Add four production-oriented AI/X-Ops resources across AI data, RAG evaluation, and AI security operations.

## Projects added
- Apache Doris
- MemoryBench
- Anthropic Cybersecurity Skills
- Kubernetes AI-BOM

## Validation
- Markdown internal-link, duplicate URL/name, and bilingual URL parity checks pass.
- `git diff --check` passes.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Changed files limited to `README.md` and `README.zh-CN.md`.

## Risk
Documentation-only change; low runtime risk. Descriptions are concise and should be revisited if upstream scope or maintenance status changes.

## Auto-merge intent
Request automatic squash merge after self-review and green or absent checks.