### PR TITLE
docs: add Lighteval to LLM evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [RAGEval](https://github.com/BytePioneer-AI/RAGEval): Open-source RAG evaluation system for automating dataset-based quality checks across retrieval and generation workflows.
 - [TruLens](https://github.com/truera/trulens): Evaluation and tracking framework for LLM experiments and AI agents with feedback functions, guardrails, and iterative improvement workflows.
 - [OpenCompass](https://github.com/open-compass/opencompass): LLM evaluation platform supporting a wide range of models across 100+ datasets with reproducible benchmarks.
+- [Lighteval](https://github.com/huggingface/lighteval): Modular toolkit for reproducible LLM evaluations across multiple backends, tasks, metrics, and distributed execution environments.
 - [OpenAI Evals](https://github.com/openai/evals): Framework for evaluating LLMs and LLM systems with an open-source registry of benchmarks and evaluation workflows.
 - [AgentBench](https://github.com/THUDM/AgentBench): Apache-2.0 benchmark for evaluating LLMs as agents across diverse environments and tasks.
 - [Olmes](https://github.com/allenai/olmes): Reproducible and flexible framework for evaluating language models across configurable benchmarks and evaluation workflows.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,7 +125,8 @@
 - [OpenEvals](https://github.com/langchain-ai/openevals)：现成的评估器集合，用于在开发和 CI 流程中测试 LLM 应用并做回归检查。
 - [RAGEval](https://github.com/BytePioneer-AI/RAGEval)：开源 RAG 评测系统，用于自动化执行覆盖检索和生成流程的数据集质量检查。
 - [TruLens](https://github.com/truera/trulens)：LLM 评估与追踪框架，支持反馈函数、护栏和迭代改进工作流，适用于 LLM 实验与 AI Agent。
-- [OpenCompass](https://github.com/open-compass/opencompass)：LLM 评估平台，支持 100+ 数据集上对多种模型的评测和可复现基准测试。
+- [OpenCompass](https://github.com/open-compass/opencompass)：LLM 评估平台，支持在 100+ 数据集上对多种模型进行评测和可复现基准测试。
+- [Lighteval](https://github.com/huggingface/lighteval)：模块化的 LLM 评估工具包，支持多种后端、任务、指标和分布式执行环境，适合构建可复现的评估流程。
 - [OpenAI Evals](https://github.com/openai/evals)：用于评估 LLM 和 LLM 系统的框架，提供开源基准测试注册表和评估工作流。
 - [AgentBench](https://github.com/THUDM/AgentBench)：基于 Apache-2.0 许可的基准测试工具，用于在多种环境和任务中评估 LLM 作为 Agent 的能力。
 - [Olmes](https://github.com/allenai/olmes)：可复现且灵活的语言模型评估框架，支持可配置的基准测试与评估工作流。


### PR DESCRIPTION
## Summary

- Add Lighteval to the LLM and Agent Observability evaluation tooling section in both README language variants.
- Keep the description focused on reproducible, modular evaluation across backends, tasks, metrics, and distributed execution.

## Projects / content added

- [Lighteval](https://github.com/huggingface/lighteval) — MIT-licensed toolkit; 2,503 GitHub stars observed during this run; repository is active and not archived.

## Validation

- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese GitHub entry sets match: 559 entries each.
- `git diff --check` passed.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Pushed branch SHA matches local HEAD.

## Risk

Documentation-only change; low runtime risk. The GitHub star count is discovery metadata captured during curation and is not written into the README.

## Auto-merge intent

Requesting automatic squash merge after PR self-review and green or absent checks. Do not bypass failing checks.
