### PR TITLE
docs: add Cognita and SuperDuper to AI infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Docling](https://github.com/docling-project/docling): IBM's open-source document understanding toolkit for converting PDFs, DOCX, PPTX, images, and HTML into LLM-ready structured formats at scale.
 - [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR): Open-source OCR toolkit for converting PDFs and images into structured data for multilingual AI and RAG pipelines.
 - [Pathway LLM App](https://github.com/pathwaycom/llm-app): Ready-to-run templates for production RAG, AI pipelines, and enterprise search with live data connectors and Docker-friendly deployment.
+- [Cognita](https://github.com/truefoundry/cognita): Open-source modular RAG framework for building production applications with configurable data ingestion, retrieval, and serving components.
+- [SuperDuper](https://github.com/superduper-io/superduper): Open-source framework for building custom AI applications and agents directly on existing data stores, with integrated model, data, and deployment workflows.
 - [Weaviate](https://github.com/weaviate/weaviate): Open-source vector database combining vector search with structured filtering and generative AI integrations.
 - [pgvector](https://github.com/pgvector/pgvector): Open-source vector similarity search extension for PostgreSQL, widely used for RAG and AI embedding storage.
 - [LanceDB](https://github.com/lancedb/lancedb): Developer-friendly embedded vector database for multimodal AI search with serverless architecture and zero-copy retrieval.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -289,6 +289,8 @@
 - [Docling](https://github.com/docling-project/docling)：IBM 开源的文档理解工具包，可将 PDF、DOCX、PPTX、图片和 HTML 转换为适合 LLM 使用的结构化格式，并支持规模化处理。
 - [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR)：开源 OCR 工具包，可将 PDF 和图片转换为结构化数据，适用于多语言 AI 与 RAG 流水线。
 - [Pathway LLM App](https://github.com/pathwaycom/llm-app)：生产级 RAG、AI 流水线和企业搜索的开箱即用模板，支持实时数据连接器和 Docker 部署。
+- [Cognita](https://github.com/truefoundry/cognita)：用于构建生产级应用的开源模块化 RAG 框架，支持可配置的数据摄取、检索和服务组件。
+- [SuperDuper](https://github.com/superduper-io/superduper)：基于现有数据存储构建定制 AI 应用和 Agent 的开源框架，集成模型、数据和部署工作流。
 - [Weaviate](https://github.com/weaviate/weaviate)：开源向量数据库，结合向量搜索、结构化过滤和生成式 AI 集成能力。
 - [pgvector](https://github.com/pgvector/pgvector)：PostgreSQL 的开源向量相似度搜索扩展，广泛用于 RAG 和 AI 嵌入存储。
 - [LanceDB](https://github.com/lancedb/lancedb)：面向开发者的嵌入式向量数据库，支持多模态 AI 搜索，采用无服务器架构和零拷贝检索。


### PR DESCRIPTION
## Summary

- Add Cognita and SuperDuper to the AI Infrastructure section.
- Keep English and Simplified Chinese README entries semantically aligned.

## Projects added

- Cognita — modular production RAG framework.
- SuperDuper — framework for custom AI applications and agents on existing data stores.

## Validation

- Markdown structural checks passed: internal links and duplicate URLs/names.
- Bilingual GitHub URL parity passed (561 URLs).
- `git diff --check` passed.
- Rebased/verified against latest `origin/main`; only `README.md` and `README.zh-CN.md` changed.

## Risk

- Documentation-only; descriptions are concise and based on the repositories’ published scope.

## Auto-merge intent

- Self-review and merge automatically if the diff remains limited to the expected README files and checks are green or absent.