### PR TITLE
docs: add AI inference selection guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 Tools for deploying, scaling, routing, and operating AI model inference workloads in production.
 
+**Selection guidance:** Separate the serving engine from the control plane: choose engines for throughput, latency, batching, and hardware support; choose operators and gateways for rollout safety, routing, quotas, autoscaling, and telemetry. Prefer projects with reproducible benchmarks and an explicit upgrade or rollback path.
+
 - [Ray Serve](https://github.com/ray-project/ray): Scalable model serving library in Ray for building distributed online inference APIs and LLM serving workloads.
 - [KubeTorch](https://github.com/run-house/kubetorch): Python-native Kubernetes control layer for distributing and running AI workloads across cluster resources.
 - [ModelPlane](https://github.com/modelplaneai/modelplane): Open-source control plane for deploying, routing, and operating AI inference workloads.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,6 +208,8 @@
 
 用于在生产环境部署、扩缩容、路由和运维 AI 模型推理负载的工具。
 
+**选择建议：** 区分推理引擎与控制平面：推理引擎重点看吞吐、延迟、批处理和硬件支持；Operator 与网关重点看发布安全、路由、配额、自动扩缩容和遥测能力。优先选择提供可复现基准，以及明确升级和回滚路径的项目。
+
 - [Ray Serve](https://github.com/ray-project/ray)：Ray 中的可扩展模型服务库，用于构建分布式在线推理 API 和 LLM 服务负载。
 - [KubeTorch](https://github.com/run-house/kubetorch)：面向 Python 的 Kubernetes 控制层，用于在集群资源上分发和运行 AI 工作负载。
 - [ModelPlane](https://github.com/modelplaneai/modelplane)：开源 AI 推理控制平面，用于部署、路由和运维推理工作负载。


### PR DESCRIPTION
## Summary
Add concise production-focused selection guidance to the AI Serving and Inference Operations section.

## Content added
- English and Simplified Chinese guidance distinguishing serving engines from control planes.
- Calls out throughput, latency, batching, hardware support, rollout safety, routing, quotas, autoscaling, telemetry, benchmarks, and rollback paths.

## Validation
- Markdown structural checks passed.
- Internal links and duplicate URL/name checks passed.
- English and Chinese project URL sets match: 574 each.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Changed files are limited to `README.md` and `README.zh-CN.md`.

## Risk
Documentation-only; no runtime or API behavior changes. The guidance is intentionally concise and may be refined as the serving ecosystem evolves.

## Auto-merge intent
Self-review required. If the diff remains scoped and checks are green or absent, merge with squash and delete the branch.
