### PR TITLE
docs: add production AI gateway resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [AgentSight](https://github.com/eunomia-bpf/agentsight): eBPF-based system-level tracing for observing AI agent execution without application instrumentation.
 - [AgentOps](https://github.com/AgentOps-AI/agentops): Python SDK for monitoring AI agents, tracking LLM costs, benchmarking runs, and integrating with common agent frameworks.
 - [LLM Gateway](https://github.com/theopenco/llmgateway): Open-source gateway for routing, managing, and analyzing LLM requests across multiple providers through one API.
+- [GoModel](https://github.com/ENTERPILOT/GoModel): Go-based AI gateway and control plane with OpenAI- and Anthropic-compatible APIs, routing, failover, guardrails, cost tracking, and operational logs.
+- [AI Proxy](https://github.com/labring/aiproxy): High-performance AI gateway with OpenAI-, Claude-, and Gemini-compatible protocols, multi-channel management, rate limiting, multi-tenant isolation, and monitoring.
 - [LLMIO](https://github.com/atopos31/llmio): Go-based LLM gateway with weighted provider routing, an admin UI, request tracing, latency and token metrics, cost tracking, and failure handling.
 - [OpenZiti LLM Gateway](https://github.com/openziti/llm-gateway): Zero-trust, OpenAI-compatible gateway with identity-based access, semantic routing, and load balancing across hosted and self-hosted model providers.
 - [Portkey AI Gateway](https://github.com/Portkey-AI/gateway): AI gateway for routing LLM traffic, applying guardrails, and centralizing model access for production applications.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,6 +98,8 @@
 - [AgentSight](https://github.com/eunomia-bpf/agentsight)：基于 eBPF 的系统级追踪工具，无需应用插桩即可观测 AI Agent 执行过程。
 - [AgentOps](https://github.com/AgentOps-AI/agentops)：用于监控 AI Agent、追踪 LLM 成本、基准测试运行并集成常见 Agent 框架的 Python SDK。
 - [LLM Gateway](https://github.com/theopenco/llmgateway)：开源 LLM 网关，通过统一 API 在多个供应商之间路由、管理和分析 LLM 请求。
+- [GoModel](https://github.com/ENTERPILOT/GoModel)：基于 Go 的 AI 网关与控制平面，提供兼容 OpenAI 和 Anthropic 的 API、路由、故障转移、护栏、成本追踪和运维日志。
+- [AI Proxy](https://github.com/labring/aiproxy)：高性能 AI 网关，支持 OpenAI、Claude 和 Gemini 兼容协议，以及多渠道管理、限流、多租户隔离和监控。
 - [LLMIO](https://github.com/atopos31/llmio)：基于 Go 的 LLM 网关，支持按权重路由供应商、管理控制台、请求追踪、延迟与 Token 指标、成本统计和故障处理。
 - [OpenZiti LLM Gateway](https://github.com/openziti/llm-gateway)：零信任、兼容 OpenAI API 的网关，支持基于身份的访问控制、语义路由，以及在托管和自托管模型供应商之间负载均衡。
 - [Portkey AI Gateway](https://github.com/Portkey-AI/gateway)：AI 网关，用于路由 LLM 流量、应用护栏，并集中管理生产应用的模型访问。


### PR DESCRIPTION
## Summary

- Add GoModel and AI Proxy to the LLM gateway coverage.
- Keep English and Simplified Chinese README entries aligned.

## Projects added

- GoModel: Go AI gateway/control plane with compatible APIs, routing, failover, guardrails, cost tracking, and logs.
- AI Proxy: AI gateway with compatible provider protocols, rate limiting, tenant isolation, and monitoring.

## Validation

- Markdown internal-link, duplicate URL/name, and bilingual parity checks passed.
- `git diff --check` passed.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk

- Documentation-only change; descriptions are concise summaries of the repositories’ current GitHub metadata.
- AI gateway overlap is intentional and limited to operationally distinct projects; future entries should avoid turning this into a catalog.

## Auto-merge intent

- Self-review first; merge with squash only if the diff remains expected and checks are green or absent.