### PR TITLE
docs: add OpenTelemetry multi-agent observability reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix): Open-source observability and evaluation platform for LLM, RAG, and ML systems.
 - [OpenInference](https://github.com/Arize-ai/openinference): OpenTelemetry instrumentation and semantic conventions for tracing LLM, RAG, and agent applications.
 - [OpenLLMetry](https://github.com/traceloop/openllmetry): OpenTelemetry-based observability for LLM applications and agent workflows.
+- [Multi-agent Observability with OpenTelemetry](https://github.com/chrisipanaque/multi-agent-observability-opentelemetry): OpenTelemetry reference implementation for tracing LangGraph multi-agent systems, including routing decisions, tool calls, LLM invocations, metrics, and OTLP export.
 - [Helicone](https://github.com/Helicone/helicone): Open-source observability platform for LLM usage, latency, cost, caching, and request logs.
 - [OpenLIT](https://github.com/openlit/openlit): OpenTelemetry-native AI engineering platform for LLM observability, evaluations, guardrails, prompt management, and GPU monitoring.
 - [Grafana AI Observability SDK](https://github.com/grafana/sigil-sdk): Open-source SDKs and coding-agent plugins for sending production agent and LLM telemetry to Grafana AI observability.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,7 @@
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix)：面向 LLM、RAG 和机器学习系统的开源可观测与评估平台。
 - [OpenInference](https://github.com/Arize-ai/openinference)：面向 LLM、RAG 和 Agent 应用的 OpenTelemetry 插桩与语义约定。
 - [OpenLLMetry](https://github.com/traceloop/openllmetry)：基于 OpenTelemetry 的 LLM 应用和 Agent 工作流可观测性工具。
+- [Multi-agent Observability with OpenTelemetry](https://github.com/chrisipanaque/multi-agent-observability-opentelemetry)：面向 LangGraph 多 Agent 系统的 OpenTelemetry 可观测性参考实现，覆盖路由决策、工具调用、LLM 调用、指标和 OTLP 导出。
 - [Helicone](https://github.com/Helicone/helicone)：开源 LLM 可观测平台，支持用量、延迟、成本、缓存和请求日志分析。
 - [OpenLIT](https://github.com/openlit/openlit)：基于 OpenTelemetry 的 AI 工程平台，支持 LLM 可观测性、评估、护栏、Prompt 管理和 GPU 监控。
 - [Grafana AI Observability SDK](https://github.com/grafana/sigil-sdk)：开源 SDK 与编码 Agent 插件，用于将生产环境 Agent 和 LLM 遥测数据发送到 Grafana AI observability。


### PR DESCRIPTION
## Summary
- Add a production-oriented OpenTelemetry reference implementation for LangGraph multi-agent observability.
- Keep English and Simplified Chinese README entries aligned.

## Projects added
- Multi-agent Observability with OpenTelemetry — traces routing decisions, tool calls, LLM invocations, metrics, and OTLP export without vendor SDK dependencies.

## Validation
- Markdown structural checks passed.
- Internal links and duplicate URL/name checks passed.
- English/Chinese project URL parity passed (577 entries).
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk
- Documentation-only change; low runtime risk. Candidate repository is active and unarchived, but its latest push is 2026-07-19, so maintenance cadence should be revisited during future curation.

## Auto-merge intent
- Self-review and merge when checks are green or absent; squash merge and delete the branch.
