### PR TITLE
docs: add Augustus LLM security testing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [OpenHack](https://github.com/openhackai/OpenHack): Open-source agentic security scanner and verifier for finding and validating vulnerabilities in codebases with open-source models.
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard): OWASP project defining inspectable, traceable, and instrumentable observability practices for trustworthy AI agents.
 - [Rogue](https://github.com/qualifire-dev/rogue): AI agent evaluation and red-team platform for regression testing, policy validation, adversarial probing, and security reporting across agent protocols.
+- [Augustus](https://github.com/praetorian-inc/augustus): Apache-2.0 LLM security testing framework that detects prompt injection, jailbreaks, and adversarial weaknesses with 190+ probes across 28 model providers.
 - [SkillHub](https://github.com/iflytek/skillhub): Self-hosted registry for publishing and versioning agent skills with RBAC, audit logs, and Docker or Kubernetes deployment.
 - [MEDUSA](https://github.com/Pantheon-Security/medusa): AI-first security scanner for AI/ML applications, agents, MCP servers, and code, with supply-chain, prompt-injection, secret, and vulnerability detection.
 - [Arcjet JS](https://github.com/arcjet/arcjet-js): Runtime security SDK for AI applications and agents with prompt-injection detection, tool-call authorization, sensitive-data redaction, bot protection, and rate limiting.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -577,8 +577,9 @@
 - [OctoBus](https://github.com/chaitin/OctoBus)：本地单二进制网关，用于管理可插拔服务，并通过 gRPC、Connect RPC 和 MCP 暴露选定能力。
 - [OpenHack](https://github.com/openhackai/OpenHack)：开源 Agent 安全扫描与验证工具，使用开源模型在代码库中发现并验证安全漏洞。
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard)：OWASP 项目，为可信 AI Agent 定义可检查、可追踪和可插桩的可观测性实践。
-- [Rogue](https://github.com/qualifire-dev/rogue)：AI Agent 评估与红队平台，支持回归测试、策略校验、对抗性探测和安全报告，覆盖多种 Agent 协议。
-- [SkillHub](https://github.com/iflytek/skillhub)：可自托管的 Agent Skill 注册中心，支持发布与版本管理、RBAC、审计日志，以及 Docker 或 Kubernetes 部署。
+- [Rogue](https://github.com/qualifire-dev/rogue)：面向 AI Agent 的评估与红队平台，支持回归测试、策略校验、对抗性探测和跨 Agent 协议的安全报告。
+- [Augustus](https://github.com/praetorian-inc/augustus)：基于 Apache-2.0 许可的 LLM 安全测试框架，使用覆盖 28 个模型供应商的 190+ 探针检测 Prompt 注入、越狱和对抗性弱点。
+- [SkillHub](https://github.com/iflytek/skillhub)：自托管 Agent Skill 注册中心，支持发布、版本管理、RBAC、审计日志，以及 Docker 或 Kubernetes 部署。
 - [MEDUSA](https://github.com/Pantheon-Security/medusa)：面向 AI/ML 应用、Agent、MCP Server 和代码的 AI 原生安全扫描器，支持供应链、Prompt 注入、Secret 和漏洞检测。
 - [Arcjet JS](https://github.com/arcjet/arcjet-js)：面向 AI 应用和 Agent 的运行时安全 SDK，支持 Prompt 注入检测、工具调用授权、敏感数据脱敏、机器人防护和限流。
 


### PR DESCRIPTION
## Summary
- Add Augustus to the Security and Supply Chain section in both README language variants.
- Document its Apache-2.0 license, 190+ probes, 28-provider coverage, and LLM security testing focus.

## Projects or content added
- Augustus — https://github.com/praetorian-inc/augustus

## Validation
- `markdown structural checks ok`
- `git diff --check`
- English and Simplified Chinese entries are aligned.
- Duplicate URL and project-name checks passed.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.

## Risk
- Low: documentation-only change. Project claims are concise and based on the repository metadata; probe/provider counts may change upstream.

## Auto-merge intent
- Self-review and merge automatically if the diff remains scoped and checks are green or absent.
