### PR TITLE
docs: add AI evaluation platforms to observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Grafana Agento11y](https://github.com/grafana/agento11y): Grafana's practical AI observability project for collecting useful telemetry from agent and LLM workflows.
 - [Agent Beacon](https://github.com/Asymptote-Labs/agent-beacon): Unified telemetry layer for AI agents running locally, in CI, or in the cloud, with a local dashboard and security-team workflows.
 - [dt-evals](https://github.com/dynatrace-oss/dt-evals): Apache-2.0 CLI with evaluators for AI applications and agents, including LLM-as-a-judge workflows that support observability feedback loops.
+- [EfficientAI](https://github.com/EfficientAI-tech/efficientAI): Open-source voice AI evaluation platform for testing, comparing, and shipping reliable voice agents.
+- [AI Eval Platform](https://github.com/huangyiminghappy/ai-eval-platform): Open-source evaluation platform for RAG, AI agents, multi-turn conversations, LLM-as-a-judge workflows, endpoint testing, reports, and blind human review.
 
 ## Kubernetes Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -474,6 +474,8 @@
 - [Grafana Agento11y](https://github.com/grafana/agento11y)：Grafana 的实用型 AI 可观测性项目，用于采集 Agent 和 LLM 工作流的有效遥测数据。
 - [Agent Beacon](https://github.com/Asymptote-Labs/agent-beacon)：面向本地、CI 和云端 AI Agent 的统一遥测层，并提供本地仪表盘和面向安全团队的工作流。
 - [dt-evals](https://github.com/dynatrace-oss/dt-evals)：Apache-2.0 许可的 AI 应用与 Agent 评估 CLI，包含 LLM-as-a-judge 评估器，可接入可观测性反馈闭环。
+- [EfficientAI](https://github.com/EfficientAI-tech/efficientAI)：开源语音 AI 评估平台，用于测试、比较并交付可靠的语音 Agent。
+- [AI Eval Platform](https://github.com/huangyiminghappy/ai-eval-platform)：开源 AI 应用评估平台，支持 RAG、AI Agent、多轮对话、LLM-as-a-judge、接口评测、评测报告和人工盲测。
 
 ## Kubernetes Operations Kubernetes 运维
 


### PR DESCRIPTION
## Summary

- Add EfficientAI and AI Eval Platform to the LLM and Agent Observability section.
- Keep English and Simplified Chinese README entries semantically aligned.

## Projects added

- EfficientAI: open-source voice AI evaluation platform for testing, comparing, and shipping reliable voice agents.
- AI Eval Platform: open-source evaluation platform covering RAG, AI agents, multi-turn conversations, LLM-as-a-judge, endpoint testing, reports, and blind human review.

## Validation

- `markdown structural checks ok`
- English and Chinese GitHub URL sets match: 567 entries.
- `git diff --check` passed.
- Candidate repositories were checked with GitHub REST metadata and HTTP 200 responses; both are active and unarchived.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Diff is limited to `README.md` and `README.zh-CN.md`.

## Risk

Documentation-only change. The main curation risk is candidate quality drift; descriptions are intentionally limited to capabilities verified from repository metadata.

## Auto-merge intent

Self-review and validation passed. Merge with squash and delete the remote branch if checks are green or absent.
