### PR TITLE
docs: add AI agent observability and security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,9 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [dt-evals](https://github.com/dynatrace-oss/dt-evals): Apache-2.0 CLI with evaluators for AI applications and agents, including LLM-as-a-judge workflows that support observability feedback loops.
 - [EfficientAI](https://github.com/EfficientAI-tech/efficientAI): Open-source voice AI evaluation platform for testing, comparing, and shipping reliable voice agents.
 - [AI Eval Platform](https://github.com/huangyiminghappy/ai-eval-platform): Open-source evaluation platform for RAG, AI agents, multi-turn conversations, LLM-as-a-judge workflows, endpoint testing, reports, and blind human review.
+- [Foglamp](https://github.com/foglamp-labs/foglamp): Apache-2.0 self-hosted observability layer for the Vercel AI SDK, covering token usage, cost, latency, traces, and prompt or response logs.
+- [HUATUO](https://github.com/ccfos/huatuo): Apache-2.0 eBPF-based observability for Linux kernels, AI-agent sandboxes, and heterogeneous infrastructure, with automatic tracing and continuous profiling.
+- [CPA Manager Plus](https://github.com/seakee/CPA-Manager-Plus): Self-hosted management panel and AI gateway observability dashboard for request history, usage, cost, quotas, failures, and account health.
 
 ## Kubernetes Operations
 
@@ -584,6 +587,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [SkillHub](https://github.com/iflytek/skillhub): Self-hosted registry for publishing and versioning agent skills with RBAC, audit logs, and Docker or Kubernetes deployment.
 - [MEDUSA](https://github.com/Pantheon-Security/medusa): AI-first security scanner for AI/ML applications, agents, MCP servers, and code, with supply-chain, prompt-injection, secret, and vulnerability detection.
 - [Arcjet JS](https://github.com/arcjet/arcjet-js): Runtime security SDK for AI applications and agents with prompt-injection detection, tool-call authorization, sensitive-data redaction, bot protection, and rate limiting.
+- [ADR](https://github.com/uber/ADR): Apache-2.0 agentic AI detection and response system combining agent telemetry, security benchmarking, and threat detection for enterprise AI agents.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -476,6 +476,9 @@
 - [dt-evals](https://github.com/dynatrace-oss/dt-evals)：Apache-2.0 许可的 AI 应用与 Agent 评估 CLI，包含 LLM-as-a-judge 评估器，可接入可观测性反馈闭环。
 - [EfficientAI](https://github.com/EfficientAI-tech/efficientAI)：开源语音 AI 评估平台，用于测试、比较并交付可靠的语音 Agent。
 - [AI Eval Platform](https://github.com/huangyiminghappy/ai-eval-platform)：开源 AI 应用评估平台，支持 RAG、AI Agent、多轮对话、LLM-as-a-judge、接口评测、评测报告和人工盲测。
+- [Foglamp](https://github.com/foglamp-labs/foglamp)：基于 Apache-2.0 许可、可自托管的 Vercel AI SDK 可观测性层，覆盖 Token 用量、成本、延迟、trace 以及 Prompt 和响应日志。
+- [HUATUO](https://github.com/ccfos/huatuo)：基于 Apache-2.0 许可的 eBPF 可观测性工具，面向 Linux 内核、AI Agent 沙箱和异构基础设施，支持自动追踪与持续性能剖析。
+- [CPA Manager Plus](https://github.com/seakee/CPA-Manager-Plus)：可自托管的管理面板与 AI 网关可观测性仪表盘，支持请求历史、用量、成本、配额、失败分析和账户健康度。
 
 ## Kubernetes Operations Kubernetes 运维
 
@@ -584,6 +587,7 @@
 - [SkillHub](https://github.com/iflytek/skillhub)：自托管 Agent Skill 注册中心，支持发布、版本管理、RBAC、审计日志，以及 Docker 或 Kubernetes 部署。
 - [MEDUSA](https://github.com/Pantheon-Security/medusa)：面向 AI/ML 应用、Agent、MCP Server 和代码的 AI 原生安全扫描器，支持供应链、Prompt 注入、Secret 和漏洞检测。
 - [Arcjet JS](https://github.com/arcjet/arcjet-js)：面向 AI 应用和 Agent 的运行时安全 SDK，支持 Prompt 注入检测、工具调用授权、敏感数据脱敏、机器人防护和限流。
+- [ADR](https://github.com/uber/ADR)：基于 Apache-2.0 许可的 Agentic AI 检测与响应系统，将 Agent 遥测、安全基准测试和威胁检测结合起来，面向企业 AI Agent。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary

Add four production-oriented AI operations projects to the bilingual catalog: three observability tools and one agent security detection system.

## Projects added

- Foglamp — Vercel AI SDK observability for cost, latency, tokens, traces, and prompt/response logs.
- HUATUO — eBPF observability and continuous profiling for Linux, AI-agent sandboxes, and heterogeneous infrastructure.
- CPA Manager Plus — self-hosted AI gateway management and usage/cost observability.
- ADR — enterprise agent telemetry, security benchmarking, and threat detection.

## Validation

- `markdown structural checks ok` (internal links, duplicate URLs/names, bilingual URL parity).
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Self-review confirmed the diff contains only `README.md` and `README.zh-CN.md` and entries are semantically aligned.

## Risk

Documentation-only change. Project capabilities and license details were checked against each repository's current GitHub README/API metadata; descriptions may require future refresh as projects evolve.

## Auto-merge intent

Auto-merge after PR self-review and green or absent checks, per repository curation policy.
