### PR TITLE
docs: add agent control plane tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Harbor Framework](https://github.com/harbor-framework/harbor): Framework for evaluating and improving agents and language models across reproducible environments and parallel experiments.
 - [LangBot](https://github.com/langbot-app/LangBot): Production-oriented multi-platform bot platform with agent workflows, knowledge bases, plugins, and integrations for chat systems.
 - [Dapr Agents](https://github.com/dapr/dapr-agents): CNCF-aligned framework for resilient, observable AI agents with durable workflows, state, messaging, MCP integration, and Kubernetes-native operations.
+- [Agent Control Plane](https://github.com/humanlayer/agentcontrolplane): Distributed scheduler for unsupervised, long-running agents with asynchronous tool calls, human feedback gates, and MCP support.
+- [Agent Control](https://github.com/agentcontrol/agent-control): Apache-2.0 control plane for governing agent runtime behavior at scale with configurable policies and extensibility.
 - [Workflow SDK](https://github.com/vercel/workflow): TypeScript SDK for adding durable execution, reliability, and observability to asynchronous applications and AI agents.
 - [LiveKit Agents](https://github.com/livekit/agents): Framework for building production-ready realtime voice and multimodal AI agents with integrations for models, tools, and telephony.
 - [Heym](https://github.com/heymrun/heym): Self-hosted AI workflow platform with visual and prompt-driven workflows, RAG, MCP, human approval, observability, evaluations, and token-cost tracking.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -399,6 +399,8 @@
 - [Harbor Framework](https://github.com/harbor-framework/harbor)：用于在可复现环境和并行实验中评估与改进 Agent 和语言模型的框架。
 - [LangBot](https://github.com/langbot-app/LangBot)：面向生产的多平台机器人平台，支持 Agent 工作流、知识库、插件，以及与多种聊天系统集成。
 - [Dapr Agents](https://github.com/dapr/dapr-agents)：与 CNCF 生态契合的 Agent 框架，提供持久化工作流、状态、消息、MCP 集成和 Kubernetes 原生运维能力，帮助构建可靠且可观测的 AI Agent。
+- [Agent Control Plane](https://github.com/humanlayer/agentcontrolplane)：面向无人值守长周期 Agent 的分布式调度器，支持异步工具调用、人机反馈门禁和 MCP。
+- [Agent Control](https://github.com/agentcontrol/agent-control)：基于 Apache-2.0 许可的控制平面，用于规模化治理 Agent 运行时行为，并支持可配置策略和扩展。
 - [Workflow SDK](https://github.com/vercel/workflow)：用于 TypeScript 的 SDK，为异步应用和 AI Agent 增加持久化执行、可靠性和可观测性。
 - [LiveKit Agents](https://github.com/livekit/agents)：用于构建生产级实时语音和多模态 AI Agent 的框架，集成模型、工具和电话系统。
 - [Heym](https://github.com/heymrun/heym)：可自托管的 AI 工作流平台，支持可视化和 Prompt 驱动工作流、RAG、MCP、人机审批、可观测性、评估和 Token 成本追踪。


### PR DESCRIPTION
## Summary

- Add Agent Control Plane and Agent Control to the Agentic Workflow section in both README language variants.
- Cover long-running scheduling, human feedback gates, MCP, runtime governance, and policy extensibility.

## Projects added

- [Agent Control Plane](https://github.com/humanlayer/agentcontrolplane)
- [Agent Control](https://github.com/agentcontrol/agent-control)

## Validation

- Markdown structural checks: passed.
- Duplicate URL and entry-name checks: passed.
- English/Chinese GitHub entry URL parity: passed (573 entries in each).
- `git diff --check`: passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk

Documentation-only change. Project maturity and scope may evolve; descriptions are intentionally concise and should be revisited if either project changes direction.

## Auto-merge intent

Auto-merge after PR self-review and green or absent checks.