### PR TITLE
docs: add MCP security operations resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,10 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [MEDUSA](https://github.com/Pantheon-Security/medusa): AI-first security scanner for AI/ML applications, agents, MCP servers, and code, with supply-chain, prompt-injection, secret, and vulnerability detection.
 - [Arcjet JS](https://github.com/arcjet/arcjet-js): Runtime security SDK for AI applications and agents with prompt-injection detection, tool-call authorization, sensitive-data redaction, bot protection, and rate limiting.
 - [ADR](https://github.com/uber/ADR): Apache-2.0 agentic AI detection and response system combining agent telemetry, security benchmarking, and threat detection for enterprise AI agents.
+- [MCP Security Checklist](https://github.com/slowmist/MCP-Security-Checklist): Practical security checklist for MCP hosts, clients, servers, multi-MCP deployments, and tool-ecosystem integrations.
+- [Google Security Operations MCP Server](https://github.com/google/mcp-security): Official MCP servers for integrating Google SecOps, Google Threat Intelligence, Security Command Center, and SOAR capabilities with AI assistants.
+- [Spring AI MCP Security](https://github.com/spring-ai-community/mcp-security): Spring AI security and authorization support for MCP clients, servers, and authorization servers, including OAuth 2.0 flows.
+- [mcp-context-protector](https://github.com/trailofbits/mcp-context-protector): Trail of Bits security wrapper for MCP servers with configuration pinning, tool-response quarantine, and prompt-injection defenses.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -590,6 +590,10 @@
 - [MEDUSA](https://github.com/Pantheon-Security/medusa)：面向 AI/ML 应用、Agent、MCP Server 和代码的 AI 原生安全扫描器，支持供应链、Prompt 注入、Secret 和漏洞检测。
 - [Arcjet JS](https://github.com/arcjet/arcjet-js)：面向 AI 应用和 Agent 的运行时安全 SDK，支持 Prompt 注入检测、工具调用授权、敏感数据脱敏、机器人防护和限流。
 - [ADR](https://github.com/uber/ADR)：基于 Apache-2.0 许可的 Agentic AI 检测与响应系统，将 Agent 遥测、安全基准测试和威胁检测结合起来，面向企业 AI Agent。
+- [MCP Security Checklist](https://github.com/slowmist/MCP-Security-Checklist)：面向 MCP Host、Client、Server、多 MCP 部署和工具生态集成的实用安全检查清单。
+- [Google Security Operations MCP Server](https://github.com/google/mcp-security)：谷歌官方 MCP Server，用于将 Google SecOps、Google Threat Intelligence、Security Command Center 和 SOAR 能力接入 AI 助手。
+- [Spring AI MCP Security](https://github.com/spring-ai-community/mcp-security)：为 Spring AI 的 MCP Client、Server 和授权服务器提供安全与授权支持，包括 OAuth 2.0 流程。
+- [mcp-context-protector](https://github.com/trailofbits/mcp-context-protector)：Trail of Bits 的 MCP Server 安全包装器，提供配置固定、工具响应隔离和 Prompt 注入防护。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary

- Add four production-oriented MCP security resources to the Security and Supply Chain section.
- Keep English and Simplified Chinese README entries semantically aligned.

## Projects added

- MCP Security Checklist
- Google Security Operations MCP Server
- Spring AI MCP Security
- mcp-context-protector

## Validation

- `git diff --check`
- Markdown internal-link, duplicate URL/name checks: passed
- English/Chinese GitHub URL parity: passed (577 URLs)
- Diff scope: `README.md`, `README.zh-CN.md` only
- Rebased onto latest `origin/main`; verified `origin/main` is an ancestor of HEAD
- Verified remote branch SHA matches local HEAD

## Risk

Documentation-only change. The main curation risk is project maturity or scope drift; the candidates were checked against their canonical GitHub repositories and current metadata. No runtime behavior changes.

## Auto-merge intent

Please review. Do not auto-merge without the repository's normal checks and maintainer approval.
