### PR TITLE
docs: add production checklist for LLM observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 **Selection guidance:** Prefer tools that connect traces to prompts, model versions, evaluations, and cost or latency signals; for RAG, favor evaluation workflows that measure retrieval and answer quality without requiring brittle golden-answer sets; use gateway, security, and serving tools in their dedicated sections when observability is not their primary operational purpose.
 
+**Production checklist:** Before adopting a tool, verify OpenTelemetry or an exportable trace format, retention and redaction controls, reproducible evaluation runs, framework coverage, and a clear path from an alert to the underlying prompt, tool call, model, and cost. A dashboard without failure evidence is just a very colorful shrug.
+
 - [LiteLLM](https://github.com/BerriAI/litellm): OpenAI-compatible LLM gateway with routing, budgets, logging, and provider abstraction.
 - [Langfuse](https://github.com/langfuse/langfuse): Open-source LLM engineering platform for traces, prompt management, evaluations, and metrics.
 - [Litefuse](https://github.com/litefuse/litefuse): Open-source LLM engineering platform for collaboratively developing, monitoring, evaluating, and debugging AI applications with self-hosted deployment.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,6 +56,8 @@
 
 **选择建议：** 优先选择能将 trace 与 Prompt、模型版本、评估结果及成本或延迟信号关联起来的工具；对于 RAG，优先选择无需依赖脆弱标准答案集、同时衡量检索和回答质量的评估工作流；如果工具的主要职责不是可观测性，应放入专门的网关、安全或推理服务分类。
 
+**生产检查清单：** 采用前确认工具支持 OpenTelemetry 或可导出的 trace 格式、保留与脱敏控制、可复现的评估运行、目标框架覆盖，以及从告警追溯到具体 Prompt、工具调用、模型和成本的清晰路径。只有仪表盘而没有失败证据，就像把生产事故换成了彩色壁纸。
+
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。
 - [Langfuse](https://github.com/langfuse/langfuse)：开源 LLM 工程平台，支持链路追踪、Prompt 管理、评估和指标分析。
 - [Litefuse](https://github.com/litefuse/litefuse)：开源 LLM 工程平台，支持协作开发、监控、评估和调试 AI 应用，并可自托管部署。


### PR DESCRIPTION
## Summary

- Add a concise production-readiness checklist to the LLM and Agent Observability section.
- Keep the English and Simplified Chinese README guidance aligned.

## Content added

- OpenTelemetry or exportable traces
- Retention and redaction controls
- Reproducible evaluation runs
- Framework coverage
- Traceable paths from alerts to prompts, tools, models, and cost

## Validation

- `markdown structural checks ok`
- `git diff --check`
- English and Chinese README files changed together
- Diff scope limited to `README.md` and `README.zh-CN.md`
- Rebasing against latest `origin/main` completed; `origin/main` is an ancestor of HEAD

## Risk

Documentation-only, low risk. The checklist is guidance, not a claim that every listed project implements every control.

## Auto-merge intent

Self-review and checks required before squash merge. Auto-merge only if the diff remains docs-only and checks are green or absent.
