### PR TITLE
docs: add RAG knowledge selection guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 
 Open-source platforms for building, managing, and querying LLM-powered knowledge bases from unstructured documents.
 
+**Selection guidance:** Treat ingestion, retrieval, evaluation, and serving as separate failure domains. Prefer projects with incremental re-indexing, source citations, connector or parser coverage, access-control boundaries, and measurable retrieval or answer-quality checks. A chatbot that cannot explain where an answer came from is a demo wearing a production badge.
+
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source platform for building, evaluating, and shipping production-ready RAG and agentic applications with ingestion, vector indexing, citations, hosting, and developer APIs.
 - [RAGFlow](https://github.com/infiniflow/ragflow): Leading open-source RAG engine that combines deep document understanding, knowledge base management, and agent capabilities for enterprise knowledge workflows.
 - [FastGPT](https://github.com/labring/FastGPT): Knowledge-based LLM application platform with out-of-the-box data processing, model invocation, RAG, and visual workflow orchestration.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -351,6 +351,8 @@
 
 用于从非结构化文档构建、管理和查询 LLM 知识库的开源平台。
 
+**选择建议：** 将数据摄取、检索、评估和服务视为不同的故障域。优先选择支持增量索引、来源引用、丰富连接器或解析器、访问控制边界，以及可量化检索或回答质量检查的项目。无法说明答案来源的聊天机器人，通常只是戴着生产帽子的 Demo。
+
 - [Agentset](https://github.com/agentset-ai/agentset)：用于构建、评估和交付生产级 RAG 与 Agent 应用的开源平台，提供数据摄取、向量索引、引用、托管和开发者 API。
 - [RAGFlow](https://github.com/infiniflow/ragflow)：领先的开源 RAG 引擎，融合深度文档理解、知识库管理和 Agent 能力，适合企业知识工作流。
 - [FastGPT](https://github.com/labring/FastGPT)：基于 LLM 的知识库应用平台，提供开箱即用的数据处理、模型调用、RAG 和可视化工作流编排。


### PR DESCRIPTION
## Summary
- Add concise production-oriented selection guidance to the LLM Knowledge section.
- Keep English and Simplified Chinese README variants aligned.

## Projects or content added
- No new project entries; add guidance covering incremental indexing, citations, connectors/parsers, access control, and measurable retrieval/answer quality.

## Validation
- Markdown internal-link, duplicate URL/name, and bilingual guidance checks passed.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Changed files are limited to `README.md` and `README.zh-CN.md`.

## Risk
- Documentation-only, low risk. Guidance may need refinement as RAG operational practices evolve.

## Auto-merge intent
- Self-review and merge automatically if checks are green or absent.