### PR TITLE
docs: add local AI gateway and privacy filter tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway): Envoy-based gateway for managing unified access to generative AI services across providers and platforms.
 - [Higress](https://github.com/higress-group/higress): AI-native API gateway built on Envoy for unified LLM provider access, canary routing, rate limiting, and multi-model observability.
 - [Bifrost](https://github.com/maximhq/bifrost): High-performance enterprise AI gateway with adaptive load balancing, guardrails, cluster mode, and 1000+ model support.
+- [Adaline Gateway](https://github.com/adaline/gateway): Fully local TypeScript gateway SDK for calling 300+ LLMs with batching, retries, caching, callbacks, and OpenTelemetry integration.
 - [Inference Gateway](https://github.com/inference-gateway/inference-gateway): Cloud-native LLM gateway for unifying providers, routing inference traffic, and exposing OpenTelemetry-friendly operations on Kubernetes.
 - [OneAIFW](https://github.com/funstory-ai/aifw): Lightweight local AI firewall for anonymizing sensitive data before LLM calls and restoring it after responses.
 - [Microsoft MCP Gateway](https://github.com/microsoft/mcp-gateway): Reverse proxy and management layer for operating MCP servers with session-aware routing and Kubernetes lifecycle support.
@@ -553,6 +554,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [ToolHive](https://github.com/stacklok/toolhive): Enterprise platform for securely running and managing MCP servers with isolation, lifecycle controls, and operational governance.
 - [Tracecat](https://github.com/TracecatHQ/tracecat): Open-source security automation platform for teams and AI agents with event-driven orchestration, monitoring, and low-code workflows.
 - [OneCLI](https://github.com/onecli/onecli): Open-source credential gateway with built-in vault for giving AI agents access to services without exposing secrets.
+- [Privacy Filter](https://github.com/packyme/privacy-filter): Pure-Go privacy gateway that redacts PII and secrets before prompts reach an LLM, with HTTP, gRPC, and embeddable package interfaces.
 - [Preloop](https://github.com/preloop/preloop): Self-hostable AI agent control plane combining an MCP firewall, model gateway, policy-as-code, human approvals, runtime observability, budgets, and audit trails.
 - [hoop](https://github.com/hoophq/hoop): Open-source layer-7 gateway for engineers and AI agents that masks sensitive data, blocks dangerous infrastructure operations, supports approvals, and records sessions across databases, Kubernetes, SSH, APIs, and MCP.
 - [Octelium](https://github.com/octelium/octelium): Self-hosted zero-trust access platform that also operates as an API, AI/LLM, MCP, Kubernetes, and container application gateway.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -140,6 +140,7 @@
 - [Envoy AI Gateway](https://github.com/envoyproxy/ai-gateway)：基于 Envoy 的 AI 网关，用于跨供应商和平台统一管理生成式 AI 服务访问。
 - [Higress](https://github.com/higress-group/higress)：基于 Envoy 的 AI 原生 API 网关，用于统一 LLM 供应商访问、金丝雀路由、限流和多模型可观测。
 - [Bifrost](https://github.com/maximhq/bifrost)：高性能企业级 AI 网关，支持自适应负载均衡、护栏、集群模式和 1000+ 模型接入。
+- [Adaline Gateway](https://github.com/adaline/gateway)：完全本地化的 TypeScript 网关 SDK，可调用 300+ 个 LLM，并支持批处理、重试、缓存、回调和 OpenTelemetry 集成。
 - [Inference Gateway](https://github.com/inference-gateway/inference-gateway)：云原生 LLM 网关，用于统一模型供应商、路由推理流量，并在 Kubernetes 上提供 OpenTelemetry 友好的运维能力。
 - [OneAIFW](https://github.com/funstory-ai/aifw)：轻量级本地 AI 防火墙，可在调用 LLM 前匿名化敏感数据，并在响应后还原。
 - [Microsoft MCP Gateway](https://github.com/microsoft/mcp-gateway)：用于运维 MCP Server 的反向代理与管理层，支持会话感知路由和 Kubernetes 生命周期管理。
@@ -553,6 +554,7 @@
 - [ToolHive](https://github.com/stacklok/toolhive)：企业级 MCP Server 安全运行与管理平台，提供隔离、生命周期控制和运维治理能力。
 - [Tracecat](https://github.com/TracecatHQ/tracecat)：面向团队和 AI Agent 的开源安全自动化平台，支持事件驱动编排、监控和低代码工作流。
 - [OneCLI](https://github.com/onecli/onecli)：开源凭据网关，内置密钥保险库，让 AI Agent 无需暴露密钥即可安全访问服务。
+- [Privacy Filter](https://github.com/packyme/privacy-filter)：纯 Go 实现的隐私网关，在 Prompt 发送给 LLM 前脱敏 PII 和密钥，并提供 HTTP、gRPC 与可嵌入的包接口。
 - [Preloop](https://github.com/preloop/preloop)：可自托管的 AI Agent 控制平面，整合 MCP 防火墙、模型网关、policy-as-code、人机审批、运行时可观测性、预算和审计轨迹。
 - [hoop](https://github.com/hoophq/hoop)：开源七层网关，面向工程师和 AI Agent 对数据库、Kubernetes、SSH、API 与 MCP 访问执行敏感数据脱敏、危险操作拦截、审批和会话记录。
 - [Octelium](https://github.com/octelium/octelium)：可自托管的零信任访问平台，同时可作为 API、AI/LLM、MCP、Kubernetes 和容器应用网关。


### PR DESCRIPTION
## Summary
Add two production-oriented AI operations tools to both README language variants.

## Projects added
- Adaline Gateway — local TypeScript multi-provider gateway SDK with retries, caching, and OpenTelemetry.
- Privacy Filter — pure-Go PII and secret redaction gateway with HTTP, gRPC, and embeddable interfaces.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English/Chinese URL parity passed.
- Diff limited to README.md and README.zh-CN.md.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD; remote branch SHA matches local HEAD.

## Risk
Documentation-only; descriptions are concise summaries of the projects' current repositories.

## Auto-merge intent
Self-review required; merge automatically only if the expected docs-only diff remains and checks are green or absent.