### PR TITLE
docs: correct SMG gateway repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Weights & Biases](https://github.com/wandb/wandb): AI developer platform for experiment tracking, model management, and monitoring ML/LLM workflows from training to production.
 - [ClearML](https://github.com/clearml/clearml): Open-source MLOps/LLMOps platform for experiment management, data pipelines, orchestration, and model serving.
 - [Helicone AI Gateway](https://github.com/Helicone/ai-gateway): Fast, lightweight Rust-based AI gateway with smart routing, caching, rate limiting, and built-in observability across 100+ LLM providers.
-- [SMG](https://github.com/lightseekorg/smg): Engine-agnostic LLM gateway in Rust with gRPC pipeline, KV cache-aware routing, WASM plugins, MCP support, and multi-tenant auth across vLLM, TensorRT-LLM, SGLang, and cloud providers.
+- [SMG](https://github.com/smg-project/smg): Engine-agnostic LLM gateway in Rust with gRPC pipeline, KV cache-aware routing, WASM plugins, MCP support, and multi-tenant auth across vLLM, TensorRT-LLM, SGLang, and cloud providers.
 - [EleutherAI LM Eval](https://github.com/EleutherAI/lm-evaluation-harness): Standardized framework for few-shot and zero-shot evaluation of language models across hundreds of tasks and benchmarks.
 - [Weave](https://github.com/wandb/weave): Toolkit for tracing, evaluating, and improving LLM applications with automatic versioning and interactive debugging workflows.
 - [Pezzo](https://github.com/pezzolabs/pezzo): Open-source LLMOps platform for prompt management, version control, A/B testing, troubleshooting, and observability.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,7 +153,7 @@
 - [Weights & Biases](https://github.com/wandb/wandb)：AI 开发者平台，提供实验追踪、模型管理和 ML/LLM 工作流监控，覆盖从训练到生产的全流程。
 - [ClearML](https://github.com/clearml/clearml)：开源 MLOps/LLMOps 平台，支持实验管理、数据流水线、编排和模型服务。
 - [Helicone AI Gateway](https://github.com/Helicone/ai-gateway)：基于 Rust 构建的快速轻量 AI 网关，支持智能路由、缓存、速率限制和内置可观测性，覆盖 100+ LLM 供应商。
-- [SMG](https://github.com/lightseekorg/smg)：Rust 编写的引擎无关 LLM 网关，支持 gRPC 管道、KV 缓存感知路由、WASM 插件、MCP 和多租户认证，覆盖 vLLM、TensorRT-LLM、SGLang 和云供应商。
+- [SMG](https://github.com/smg-project/smg)：Rust 编写的引擎无关 LLM 网关，支持 gRPC 管道、KV 缓存感知路由、WASM 插件、MCP 和多租户认证，覆盖 vLLM、TensorRT-LLM、SGLang 和云供应商。
 - [EleutherAI LM Eval](https://github.com/EleutherAI/lm-evaluation-harness)：用于语言模型的标准化 few-shot 和 zero-shot 评估框架，覆盖数百个任务和基准测试。
 - [Weave](https://github.com/wandb/weave)：用于追踪、评估和改进 LLM 应用的工具包，支持自动版本控制和交互式调试工作流。
 - [Pezzo](https://github.com/pezzolabs/pezzo)：开源 LLMOps 平台，支持 Prompt 管理、版本控制、A/B 测试、故障排查和可观测性。


### PR DESCRIPTION
## Summary

- Correct the SMG repository URL in both README language variants.
- Preserve the existing bilingual description and category placement.

## Projects or content added

- SMG (`smg-project/smg`) canonical GitHub repository link.

## Validation

- Markdown structural checks passed.
- `git diff --check` passed.
- Worktree rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Verified the repository is active, not archived, and currently has 451 GitHub stars via `gh api`.

## Risk

- Documentation-only URL correction; low risk.

## Auto-merge intent

- Self-review and merge automatically if the expected diff is unchanged and checks are green or absent.