### PR TITLE
docs: add AI infrastructure selection guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 
 Infrastructure for web crawling, AI-ready extraction, search intelligence, and RAG data acquisition workflows.
 
+**Selection guidance:** Separate acquisition from retrieval: crawlers and parsers should expose provenance, incremental refresh, rate-limit controls, and failure visibility; vector or hybrid search layers should make indexing, filtering, access control, and relevance evaluation explicit. Prefer components that can be operated independently rather than opaque end-to-end demos.
+
 - [Firecrawl](https://github.com/firecrawl/firecrawl): Web search, scraping, crawling, and extraction API that turns web data into LLM-ready Markdown and structured outputs.
 - [Crawl4AI](https://github.com/unclecode/crawl4ai): Open-source LLM-friendly web crawler and scraper for building RAG, agent, and web data pipelines.
 - [Jina Reader](https://github.com/jina-ai/reader): URL-to-LLM converter that turns any web page into clean, LLM-friendly Markdown with a simple prefix.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -287,6 +287,8 @@
 
 用于 Web 爬取、AI 友好抽取、搜索情报和 RAG 数据采集工作流的基础设施。
 
+**选择建议：** 将数据采集与检索分开评估：爬虫和解析器应提供来源追踪、增量刷新、限流控制和失败可见性；向量或混合检索层应明确索引、过滤、访问控制和相关性评估。优先选择可以独立运维的组件，而不是不透明的端到端演示。
+
 - [Firecrawl](https://github.com/firecrawl/firecrawl)：Web 搜索、抓取、爬取与抽取 API，可将网页数据转换为适合 LLM 使用的 Markdown 和结构化输出。
 - [Crawl4AI](https://github.com/unclecode/crawl4ai)：面向 LLM 的开源 Web 爬虫与抓取工具，适合构建 RAG、Agent 和 Web 数据流水线。
 - [Jina Reader](https://github.com/jina-ai/reader)：URL 转 LLM 输入工具，通过简单前缀将任意网页转为清理后的 LLM 友好 Markdown 格式。


### PR DESCRIPTION
## Summary

Add a concise AI Infrastructure selection guide to both bilingual README files.

## Content added

- Guidance for separating web acquisition from retrieval operations.
- Checks for provenance, incremental refresh, rate limits, failure visibility, indexing, access control, and relevance evaluation.

## Validation

- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese README changes are semantically aligned.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Changed files limited to `README.md` and `README.zh-CN.md`.

## Risk

Low: documentation-only wording change; no project links or runtime code changed.

## Auto-merge intent

Self-review required; merge automatically with squash if checks are green or absent and the diff remains documentation-only.