### PR TITLE
docs: add agent security harness to security map

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [OctoBus](https://github.com/chaitin/OctoBus): Local single-binary gateway for managing pluggable services and exposing selected capabilities through gRPC, Connect RPC, and MCP.
 - [OpenHack](https://github.com/openhackai/OpenHack): Open-source agentic security scanner and verifier for finding and validating vulnerabilities in codebases with open-source models.
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard): OWASP project defining inspectable, traceable, and instrumentable observability practices for trustworthy AI agents.
+- [Agent Security Harness](https://github.com/msaleme/red-team-blue-team-agent-fabric): Executable security-testing harness for AI agents covering MCP, A2A, tool-use governance, and agentic supply-chain scenarios.
 - [Rogue](https://github.com/qualifire-dev/rogue): AI agent evaluation and red-team platform for regression testing, policy validation, adversarial probing, and security reporting across agent protocols.
 - [Augustus](https://github.com/praetorian-inc/augustus): Apache-2.0 LLM security testing framework that detects prompt injection, jailbreaks, and adversarial weaknesses with 190+ probes across 28 model providers.
 - [SkillHub](https://github.com/iflytek/skillhub): Self-hosted registry for publishing and versioning agent skills with RBAC, audit logs, and Docker or Kubernetes deployment.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -599,6 +599,7 @@
 - [OctoBus](https://github.com/chaitin/OctoBus)：本地单二进制网关，用于管理可插拔服务，并通过 gRPC、Connect RPC 和 MCP 暴露选定能力。
 - [OpenHack](https://github.com/openhackai/OpenHack)：开源 Agent 安全扫描与验证工具，使用开源模型在代码库中发现并验证安全漏洞。
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard)：OWASP 项目，为可信 AI Agent 定义可检查、可追踪和可插桩的可观测性实践。
+- [Agent Security Harness](https://github.com/msaleme/red-team-blue-team-agent-fabric)：面向 AI Agent 的可执行安全测试框架，覆盖 MCP、A2A、工具使用治理和 Agent 供应链场景。
 - [Rogue](https://github.com/qualifire-dev/rogue)：面向 AI Agent 的评估与红队平台，支持回归测试、策略校验、对抗性探测和跨 Agent 协议的安全报告。
 - [Augustus](https://github.com/praetorian-inc/augustus)：基于 Apache-2.0 许可的 LLM 安全测试框架，使用覆盖 28 个模型供应商的 190+ 探针检测 Prompt 注入、越狱和对抗性弱点。
 - [SkillHub](https://github.com/iflytek/skillhub)：自托管 Agent Skill 注册中心，支持发布、版本管理、RBAC、审计日志，以及 Docker 或 Kubernetes 部署。


### PR DESCRIPTION
## Summary
- Add Agent Security Harness to the Security and Supply Chain section in both README language variants.
- Keep the entry focused on executable AI-agent security testing across MCP, A2A, tool governance, and supply-chain scenarios.

## Projects or content added
- Agent Security Harness — https://github.com/msaleme/red-team-blue-team-agent-fabric

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- English and Simplified Chinese GitHub entry URL sets are identical (605 each).
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- PR self-review: changed files are limited to `README.md` and `README.zh-CN.md`; bilingual entry meaning is aligned.

## Risk
- Documentation-only, low runtime risk. Repository star counts and candidate signals were checked via GitHub API/search during curation; no counts are embedded.

## Auto-merge intent
- Auto-merge after self-review and checks are green or absent.