### PR TITLE
docs: add production agent frameworks to workflow map

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,10 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Claude Code Router](https://github.com/musistudio/claude-code-router): Local control plane for routing Claude Code requests across model providers and orchestrating agent capabilities.
 - [ClawManager](https://github.com/Yuan-lab-LLM/ClawManager): Kubernetes-native control plane for governing AI agent instances, runtime orchestration, AI access, and reusable resources across agent runtimes.
 - [Archestra](https://github.com/archestra-ai/archestra): Enterprise AI platform with guardrails, an MCP registry, gateway, and orchestration for governed agent operations.
+- [Microsoft Agent Framework](https://github.com/microsoft/agent-framework): MIT-licensed framework for building, orchestrating, and deploying AI agents and multi-agent workflows across Python and .NET.
+- [OpenAI Agents SDK](https://github.com/openai/openai-agents-python): Lightweight Python framework for multi-agent workflows with tools, handoffs, guardrails, and tracing-oriented runtime patterns.
+- [Strands Agents Harness SDK](https://github.com/strands-agents/harness-sdk): Apache-2.0 SDK for building and controlling production AI-agent harnesses in Python and TypeScript across models and clouds.
+- [Deep Agents](https://github.com/langchain-ai/deepagents): Batteries-included agent harness for long-running tasks with planning, subagents, filesystem access, and operational workflow composition.
 
 ## DataOps
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -420,6 +420,10 @@
 - [Claude Code Router](https://github.com/musistudio/claude-code-router)：本地 AI Agent 控制平面，可在多个模型供应商之间路由 Claude Code 请求，并编排 Agent 能力。
 - [ClawManager](https://github.com/Yuan-lab-LLM/ClawManager)：Kubernetes 原生控制平面，用于治理 AI Agent 实例、编排运行时、管理 AI 访问，并复用跨运行时资源。
 - [Archestra](https://github.com/archestra-ai/archestra)：面向企业的 AI 平台，提供安全护栏、MCP 注册中心、网关和编排能力，用于治理 Agent 运维。
+- [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)：MIT 许可的 AI Agent 框架，支持使用 Python 和 .NET 构建、编排和部署 AI Agent 及多 Agent 工作流。
+- [OpenAI Agents SDK](https://github.com/openai/openai-agents-python)：轻量级 Python 多 Agent 工作流框架，提供工具调用、交接、护栏和面向追踪的运行时能力。
+- [Strands Agents Harness SDK](https://github.com/strands-agents/harness-sdk)：Apache-2.0 许可的 SDK，用于在 Python 和 TypeScript 中构建并控制跨模型、跨云的生产级 AI Agent Harness。
+- [Deep Agents](https://github.com/langchain-ai/deepagents)：开箱即用的 Agent Harness，面向长周期任务提供规划、子 Agent、文件系统访问和运维工作流编排能力。
 
 ## DataOps
 


### PR DESCRIPTION
## Summary

Add four production-oriented agent frameworks to the Agentic Workflow map in both README language variants.

## Projects added

- Microsoft Agent Framework
- OpenAI Agents SDK
- Strands Agents Harness SDK
- Deep Agents

## Validation

- Markdown structural checks: passed
- Bilingual GitHub entry parity: passed
- Duplicate URL and entry-name checks: passed
- `git diff --check`: passed
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD
- Diff limited to `README.md` and `README.zh-CN.md`

## Risk

Documentation-only change; descriptions are concise and may need future wording updates as project scopes evolve.

## Auto-merge intent

After self-review and green or absent checks, squash-merge this PR and delete the branch.