### PR TITLE
docs: add production agent memory tools to LLM knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,9 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [GraphRAG](https://github.com/microsoft/graphrag): Microsoft's modular graph-based RAG system for extracting knowledge graphs from documents and improving retrieval quality.
 - [Mem0](https://github.com/mem0ai/mem0): Universal memory layer for AI agents with multi-level memory, entity linking, and temporal reasoning for personalized interactions.
 - [Zep](https://github.com/getzep/zep): Open-source memory layer for AI agents providing long-term recall, user facts, and knowledge graph capabilities for persistent agent memory.
+- [Graphiti](https://github.com/getzep/graphiti): Open-source engine for building temporally aware, real-time knowledge graphs that give AI agents structured, continuously updated context.
+- [Memori](https://github.com/MemoriLabs/Memori): LLM-agnostic memory infrastructure that turns agent execution and conversations into persistent, structured state for production systems.
+- [Memvid](https://github.com/memvid/memvid): Serverless, single-file memory layer for agents that provides local-first retrieval without the operational overhead of a multi-service RAG stack.
 - [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG): Open-source framework for RAG evaluation and optimization with AutoML-style automation for pipeline tuning.
 - [MemoryBench](https://github.com/supermemoryai/memorybench): Unified benchmark for evaluating conversational memory and RAG across multiple datasets.
 - [MemPalace](https://github.com/MemPalace/mempalace): Open-source AI memory system with best-in-class benchmarks, providing persistent knowledge storage for AI agents and LLM applications.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -371,6 +371,9 @@
 - [GraphRAG](https://github.com/microsoft/graphrag)：微软开源的模块化图谱 RAG 系统，可从文档中提取知识图谱以提升检索质量。
 - [Mem0](https://github.com/mem0ai/mem0)：面向 AI Agent 的通用记忆层，支持多级记忆、实体链接和时间推理，实现个性化交互。
 - [Zep](https://github.com/getzep/zep)：开源 AI Agent 记忆层，提供长期记忆召回、用户事实和知识图谱能力，实现持久的 Agent 记忆。
+- [Graphiti](https://github.com/getzep/graphiti)：开源引擎，用于构建具备时间感知能力、实时更新的知识图谱，为 AI Agent 提供结构化且持续更新的上下文。
+- [Memori](https://github.com/MemoriLabs/Memori)：与 LLM 解耦的记忆基础设施，将 Agent 执行过程和对话转化为生产系统可持久化的结构化状态。
+- [Memvid](https://github.com/memvid/memvid)：面向 Agent 的无服务器单文件记忆层，以本地优先的方式提供检索，避免多服务 RAG 栈的运维开销。
 - [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG)：开源 RAG 评估与优化框架，通过 AutoML 风格自动化进行流水线调优。
 - [MemoryBench](https://github.com/supermemoryai/memorybench)：用于在多个数据集上评估对话记忆和 RAG 能力的统一基准测试工具。
 - [MemPalace](https://github.com/MemPalace/mempalace)：开源 AI 记忆系统，提供基准测试最优的持久化知识存储能力，适用于 AI Agent 和 LLM 应用。


### PR DESCRIPTION
## Summary
- Expand the LLM Knowledge map with production-oriented agent memory and knowledge-graph infrastructure.
- Keep English and Simplified Chinese catalogs aligned.

## Projects added
- Graphiti — temporal, real-time knowledge graphs for AI agents.
- Memori — LLM-agnostic persistent agent state infrastructure.
- Memvid — local-first, single-file agent memory and retrieval.

## Validation
- Markdown internal-link and duplicate-name/URL checks passed.
- English/Chinese catalog URL parity passed.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- GitHub repository metadata checked: all three candidates are non-archived; current star counts were verified with `gh api` (Graphiti 29,739; Memori 15,746; Memvid 16,200).

## Risk
- Descriptions are concise summaries of repository positioning; project scope and operational maturity should be revisited during normal curation review.

## Auto-merge intent
Self-review required. Auto-merge with squash and remote branch deletion if the expected docs-only diff remains unchanged and checks are green or absent.
