### PR TITLE
docs: add local AI coding agent observability tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Agenta](https://github.com/Agenta-AI/agenta): Open-source LLMOps platform for prompt management, playgrounds, evaluations, and observability.
 - [abtop](https://github.com/graykode/abtop): htop-style terminal monitor for AI coding agent sessions, tokens, context windows, rate limits, and ports.
 - [agenttrace](https://github.com/luoyuctl/agenttrace): Local-first TUI for inspecting AI coding agent cost, tokens, latency, failures, and reports.
+- [agentacct](https://github.com/mikehasa/agentacct): Local-first terminal dashboard that joins coding-agent session usage with recorded work steps, checks, provider limits, and estimated cost.
+- [agentglass](https://github.com/SirAllap/agentglass): Local-first cockpit for monitoring coding-agent sessions, tool calls, tokens, costs, and latency through hooks or OpenTelemetry, with optional approval controls.
 - [OpenTelemetry MCP Server](https://github.com/traceloop/opentelemetry-mcp-server): Unified MCP server for querying OpenTelemetry traces across Jaeger, Tempo, Traceloop, and other backends so AI agents can investigate distributed systems.
 - [Opik MCP](https://github.com/comet-ml/opik-mcp): MCP server for reading Opik traces, logging evaluation scores, and managing prompts from AI coding clients.
 - [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay): Multi-language agent runtime and middleware library for managing execution scopes, lifecycle events, and tool or LLM call telemetry.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,6 +81,8 @@
 - [Agenta](https://github.com/Agenta-AI/agenta)：开源 LLMOps 平台，支持 Prompt 管理、调试 playground、评估和可观测性。
 - [abtop](https://github.com/graykode/abtop)：类似 htop 的终端监控工具，用于查看 AI 编码 Agent 会话、Token、上下文窗口、速率限制和端口。
 - [agenttrace](https://github.com/luoyuctl/agenttrace)：本地优先的 TUI，用于检查 AI 编码 Agent 的成本、Token、延迟、失败和报告。
+- [agentacct](https://github.com/mikehasa/agentacct)：本地优先的终端仪表盘，将编码 Agent 会话用量与记录的工作步骤、检查结果、供应商限额和成本估算关联起来。
+- [agentglass](https://github.com/SirAllap/agentglass)：本地优先的控制台，可通过 hooks 或 OpenTelemetry 监控编码 Agent 会话、工具调用、Token、成本和延迟，并提供可选的审批控制。
 - [OpenTelemetry MCP Server](https://github.com/traceloop/opentelemetry-mcp-server)：统一的 MCP Server，可查询 Jaeger、Tempo、Traceloop 等后端的 OpenTelemetry 链路，让 AI Agent 能够调查分布式系统。
 - [Opik MCP](https://github.com/comet-ml/opik-mcp)：面向 AI 编码客户端的 MCP Server，可读取 Opik trace、记录评估分数并管理 Prompt。
 - [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay)：多语言 Agent 运行时与中间件库，用于管理执行作用域、生命周期事件以及工具或 LLM 调用遥测。


### PR DESCRIPTION
## Summary
- Add three local-first AI coding-agent observability tools to both README language variants.

## Projects added
- agentacct — joins local agent usage with recorded work steps and checks.
- agentglass — monitors agent sessions, tool calls, cost, latency, and optional approvals.
- CodeBurn was already present in the Platform Engineering list; it was not duplicated.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Chinese GitHub entry URL sets match.
- `git diff --check` passed.
- Diff limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk
- Documentation-only, low runtime risk. Project capabilities and star counts can change upstream; descriptions intentionally avoid hard-coded counts.

## Auto-merge intent
- Self-review required. Merge with squash only if the expected docs-only diff remains clean and checks are green or absent.
