### PR TITLE
docs: add production GenAI deployment and guardrail resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 
 **Selection guidance:** Separate the serving engine from the control plane: choose engines for throughput, latency, batching, and hardware support; choose operators and gateways for rollout safety, routing, quotas, autoscaling, and telemetry. Prefer projects with reproducible benchmarks and an explicit upgrade or rollback path.
 
+- [GenAI Factory](https://github.com/GoogleCloudPlatform/genai-factory): Production-oriented blueprints for deploying generative AI infrastructure on Google Cloud with infrastructure as code and security best practices.
+- [GenAI on EKS Starter Kit](https://github.com/aws-samples/sample-genai-on-eks-starter-kit): Kubernetes deployment blueprint combining an AI gateway, LLM serving, vector databases, embedding models, and observability on Amazon EKS.
 - [Ray Serve](https://github.com/ray-project/ray): Scalable model serving library in Ray for building distributed online inference APIs and LLM serving workloads.
 - [KubeTorch](https://github.com/run-house/kubetorch): Python-native Kubernetes control layer for distributing and running AI workloads across cluster resources.
 - [ModelPlane](https://github.com/modelplaneai/modelplane): Open-source control plane for deploying, routing, and operating AI inference workloads.
@@ -549,6 +551,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 
 ## Security and Supply Chain
 
+- [Fast LLM Security Guardrails](https://github.com/ZenGuard-AI/fast-llm-security-guardrails): Low-latency trust layer for screening and enforcing security policies around AI-agent and LLM interactions.
 - [Falco](https://github.com/falcosecurity/falco): CNCF runtime security tool for detecting suspicious behavior in containers and Kubernetes.
 - [Tetragon](https://github.com/cilium/tetragon): eBPF-based security observability and runtime enforcement tool for detecting and blocking suspicious kernel, container, and network activity in real time.
 - [Kyverno](https://github.com/kyverno/kyverno): Kubernetes-native policy engine for validation, mutation, generation, and image verification.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,6 +223,8 @@
 
 **选择建议：** 区分推理引擎与控制平面：推理引擎重点看吞吐、延迟、批处理和硬件支持；Operator 与网关重点看发布安全、路由、配额、自动扩缩容和遥测能力。优先选择提供可复现基准，以及明确升级和回滚路径的项目。
 
+- [GenAI Factory](https://github.com/GoogleCloudPlatform/genai-factory)：面向生产的生成式 AI 基础设施蓝图，使用基础设施即代码在 Google Cloud 上部署，并遵循安全最佳实践。
+- [GenAI on EKS Starter Kit](https://github.com/aws-samples/sample-genai-on-eks-starter-kit)：面向 Amazon EKS 的 Kubernetes 部署蓝图，整合 AI 网关、LLM 服务、向量数据库、Embedding 模型和可观测性组件。
 - [Ray Serve](https://github.com/ray-project/ray)：Ray 中的可扩展模型服务库，用于构建分布式在线推理 API 和 LLM 服务负载。
 - [KubeTorch](https://github.com/run-house/kubetorch)：面向 Python 的 Kubernetes 控制层，用于在集群资源上分发和运行 AI 工作负载。
 - [ModelPlane](https://github.com/modelplaneai/modelplane)：开源 AI 推理控制平面，用于部署、路由和运维推理工作负载。
@@ -549,6 +551,7 @@
 
 ## Security and Supply Chain 安全与供应链
 
+- [Fast LLM Security Guardrails](https://github.com/ZenGuard-AI/fast-llm-security-guardrails)：面向 AI Agent 和 LLM 交互的低延迟信任层，用于筛查并执行安全策略。
 - [Falco](https://github.com/falcosecurity/falco)：CNCF 运行时安全工具，用于检测容器和 Kubernetes 中的可疑行为。
 - [Tetragon](https://github.com/cilium/tetragon)：基于 eBPF 的安全可观测与运行时执行工具，实时检测和拦截内核、容器及网络层的可疑活动。
 - [Kyverno](https://github.com/kyverno/kyverno)：Kubernetes 原生策略引擎，支持校验、变更、生成和镜像验证。


### PR DESCRIPTION
## Summary
- Add production-oriented GenAI deployment blueprints for Google Cloud and Amazon EKS.
- Add a focused AI-agent/LLM security guardrail resource.
- Keep English and Simplified Chinese README entries aligned.

## Projects added
- GenAI Factory
- GenAI on EKS Starter Kit
- Fast LLM Security Guardrails

## Validation
- Markdown internal-link and duplicate URL/name checks passed.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Documentation-only diff contains `README.md` and `README.zh-CN.md`.

## Risk
- Descriptions are concise catalog summaries; deployment-specific claims remain subject to upstream documentation.

## Auto-merge intent
- Requesting squash auto-merge after clean self-review and green or absent checks.