### PR TITLE
docs: add OpenJudge and Dingo evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [aws-bench](https://github.com/aws-bench/aws-bench): Benchmark for evaluating coding agents on real AWS tasks in disposable environments, with verifiers for diagnosis, provisioning, and operations.
 - [claw-swe-bench](https://github.com/opensquilla/claw-swe-bench): Adapter framework for evaluating OpenClaw-style agent harnesses on reproducible SWE-bench issue-resolution tasks.
 - [OpenAgent Eval](https://github.com/OpenAgentHQ/openagent-eval): Local-first, framework-agnostic evaluation framework for RAG systems and AI agents with CLI, SDK, and multiple metrics.
+- [OpenJudge](https://github.com/agentscope-ai/OpenJudge): Open-source evaluation framework for AI applications with reusable graders, scenario-specific rubrics, scalable runs, and reward signals for continuous optimization.
 - [AgentEval (.NET)](https://github.com/AgentEvalHQ/AgentEval): .NET toolkit for evaluating AI agents with tool-use validation, RAG quality metrics, stochastic testing, and model comparison.
 - [LLM Space](https://github.com/deer-flow/llm-space): Local-first desktop workspace for prototyping agents, inspecting harness steps, replaying failures, and evaluating agent performance.
 - [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym): Open framework for evaluating and improving models and agents through configurable environments and evaluation workflows.
@@ -444,6 +445,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [DataHub](https://github.com/datahub-project/datahub): Metadata platform for data discovery, lineage, governance, and observability across modern data and AI stacks.
 - [OpenMetadata](https://github.com/open-metadata/OpenMetadata): Unified metadata platform for data discovery, lineage, governance, and data observability.
 - [Great Expectations](https://github.com/great-expectations/great_expectations): Data quality framework for validating datasets, documenting expectations, and catching pipeline regressions.
+- [Dingo](https://github.com/MigoXLab/dingo): Open-source AI data-quality evaluation tool for validating LLM datasets, detecting hallucinations, and checking RAG application quality.
 - [Soda Core](https://github.com/sodadata/soda-core): Data contracts and quality checks engine for validating data pipelines in modern data stacks.
 - [Elementary](https://github.com/elementary-data/elementary): dbt-native data observability platform for monitoring pipelines, tests, freshness, and anomalies.
 - [OpenLineage](https://github.com/OpenLineage/OpenLineage): Open standard and tooling for collecting lineage metadata across data pipelines and platforms.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -202,6 +202,7 @@
 - [aws-bench](https://github.com/aws-bench/aws-bench)：在一次性环境中评估编码 Agent 执行真实 AWS 任务能力的基准工具，支持诊断、资源配置和运维任务验证。
 - [claw-swe-bench](https://github.com/opensquilla/claw-swe-bench)：用于在可复现 SWE-bench Issue 修复任务上评估 OpenClaw 风格 Agent Harness 的适配器框架。
 - [OpenAgent Eval](https://github.com/OpenAgentHQ/openagent-eval)：本地优先、框架无关的 RAG 与 AI Agent 评估框架，提供 CLI、SDK 和多种评估指标。
+- [OpenJudge](https://github.com/agentscope-ai/OpenJudge)：面向 AI 应用的开源评估框架，提供可复用 Grader、场景化评测规则、规模化运行和用于持续优化的奖励信号。
 - [AgentEval (.NET)](https://github.com/AgentEvalHQ/AgentEval)：面向 .NET 的 AI Agent 评估工具包，支持工具调用校验、RAG 质量指标、随机性测试和模型对比。
 - [LLM Space](https://github.com/deer-flow/llm-space)：本地优先的桌面工作台，用于构建 Agent 原型、检查 Harness 每一步、回放失败过程并评估 Agent 性能。
 - [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym)：用于通过可配置环境和评估工作流评估与改进模型及 Agent 的开源框架。
@@ -444,6 +445,7 @@
 - [DataHub](https://github.com/datahub-project/datahub)：面向现代数据与 AI 技术栈的元数据平台，支持数据发现、血缘、治理和可观测性。
 - [OpenMetadata](https://github.com/open-metadata/OpenMetadata)：统一元数据平台，支持数据发现、血缘、治理和数据可观测性。
 - [Great Expectations](https://github.com/great-expectations/great_expectations)：数据质量框架，用于验证数据集、记录数据期望并发现流水线回归。
+- [Dingo](https://github.com/MigoXLab/dingo)：开源 AI 数据质量评估工具，用于验证 LLM 数据集、检测幻觉并检查 RAG 应用质量。
 - [Soda Core](https://github.com/sodadata/soda-core)：面向现代数据栈的数据契约和质量检查引擎，用于验证数据流水线。
 - [Elementary](https://github.com/elementary-data/elementary)：dbt 原生数据可观测平台，用于监控流水线、测试、新鲜度和异常。
 - [OpenLineage](https://github.com/OpenLineage/OpenLineage)：用于在数据流水线和平台之间采集血缘元数据的开放标准与工具集。


### PR DESCRIPTION
## Summary
- Add OpenJudge to the LLM and Agent Observability section in both README variants.
- Add Dingo to DataOps as an AI data-quality and RAG evaluation tool in both README variants.

## Projects added
- OpenJudge — reusable graders, scenario-specific rubrics, scalable AI application evaluation, and reward signals.
- Dingo — LLM dataset, hallucination, and RAG quality evaluation.

## Validation
- Markdown structural checks: passed.
- Internal links, duplicate URLs, and duplicate entry names: passed.
- English/Chinese entry URLs: parity verified.
- git diff --check: passed.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk
- Documentation-only change; descriptions are concise summaries of the projects' public repositories.

## Auto-merge intent
- Self-review the focused bilingual diff and merge with squash if checks are green or absent.