### PR TITLE
docs: add Polyaxon to AI inference operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [Ray Serve](https://github.com/ray-project/ray): Scalable model serving library in Ray for building distributed online inference APIs and LLM serving workloads.
 - [KubeTorch](https://github.com/run-house/kubetorch): Python-native Kubernetes control layer for distributing and running AI workloads across cluster resources.
 - [ModelPlane](https://github.com/modelplaneai/modelplane): Open-source control plane for deploying, routing, and operating AI inference workloads.
+- [Polyaxon](https://github.com/polyaxon/polyaxon): Open-source AI infrastructure and orchestration platform for managing reproducible ML and LLM workloads across development and production.
 - [Triton Inference Server](https://github.com/triton-inference-server/server): Optimized inference server for deploying AI models across GPUs, CPUs, and cloud or edge environments.
 - [KServe](https://github.com/kserve/kserve): Kubernetes-native platform for standardized, scalable generative and predictive AI inference serving.
 - [LitServe](https://github.com/Lightning-AI/LitServe): Minimal Python framework for building custom AI inference servers with explicit control over batching, request logic, and scaling.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -229,6 +229,7 @@
 - [Ray Serve](https://github.com/ray-project/ray)：Ray 中的可扩展模型服务库，用于构建分布式在线推理 API 和 LLM 服务负载。
 - [KubeTorch](https://github.com/run-house/kubetorch)：面向 Python 的 Kubernetes 控制层，用于在集群资源上分发和运行 AI 工作负载。
 - [ModelPlane](https://github.com/modelplaneai/modelplane)：开源 AI 推理控制平面，用于部署、路由和运维推理工作负载。
+- [Polyaxon](https://github.com/polyaxon/polyaxon)：开源 AI 基础设施与编排平台，用于在开发和生产环境管理可复现的 ML 与 LLM 工作负载。
 - [Triton Inference Server](https://github.com/triton-inference-server/server)：优化的推理服务器，用于在 GPU、CPU、云端和边缘环境部署 AI 模型。
 - [KServe](https://github.com/kserve/kserve)：Kubernetes 原生平台，用于标准化、可扩展地服务生成式和预测式 AI 推理。
 - [LitServe](https://github.com/Lightning-AI/LitServe)：简洁的 Python 框架，用于构建自定义 AI 推理服务器，并精细控制批处理、请求逻辑和扩缩容。


### PR DESCRIPTION
## Summary
- Add Polyaxon to the AI Serving and Inference Operations map.
- Keep English and Simplified Chinese README entries aligned.

## Projects or content added
- Polyaxon — open-source AI infrastructure and orchestration for reproducible ML and LLM workloads.

## Validation
- Markdown structural checks: passed
- Bilingual URL/entry parity: passed
- `git diff --check`: passed
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Changed files limited to `README.md` and `README.zh-CN.md`.

## Risk
- Documentation-only change; low runtime risk. Project fit and current repository status should be revisited during future curation.

## Auto-merge intent
- Self-reviewed; merge automatically after checks are green or absent.