### PR TITLE
docs: add MCP gateway and fine-grained authorization tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 
 **Selection guidance:** Separate acquisition from retrieval: crawlers and parsers should expose provenance, incremental refresh, rate-limit controls, and failure visibility; vector or hybrid search layers should make indexing, filtering, access control, and relevance evaluation explicit. Prefer components that can be operated independently rather than opaque end-to-end demos.
 
+- [MetaMCP](https://github.com/metatool-ai/metamcp): Self-hosted MCP aggregator, orchestrator, middleware, and gateway for composing and governing tool servers.
 - [Firecrawl](https://github.com/firecrawl/firecrawl): Web search, scraping, crawling, and extraction API that turns web data into LLM-ready Markdown and structured outputs.
 - [Crawl4AI](https://github.com/unclecode/crawl4ai): Open-source LLM-friendly web crawler and scraper for building RAG, agent, and web data pipelines.
 - [Jina Reader](https://github.com/jina-ai/reader): URL-to-LLM converter that turns any web page into clean, LLM-friendly Markdown with a simple prefix.
@@ -745,6 +746,7 @@ Infrastructure as Code manages and provisions infrastructure through code instea
 
 Trusting is hard. Knowing who to trust is even harder.
 
+- [OpenFGA](https://github.com/openfga/openfga): High-performance authorization engine inspired by Google Zanzibar for fine-grained, relationship-based access control.
 - [keycloak](https://github.com/keycloak/keycloak): Open-source IAM for modern applications and services.
 - [OpenBao](https://github.com/openbao/openbao): Open-source secrets management system for storing and distributing secrets, certificates, and keys.
 - [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy): Lightweight OAuth2 reverse proxy for Google, Azure, OpenID Connect, and more, with simple authorization checks.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -301,6 +301,7 @@
 
 **选择建议：** 将数据采集与检索分开评估：爬虫和解析器应提供来源追踪、增量刷新、限流控制和失败可见性；向量或混合检索层应明确索引、过滤、访问控制和相关性评估。优先选择可以独立运维的组件，而不是不透明的端到端演示。
 
+- [MetaMCP](https://github.com/metatool-ai/metamcp)：可自托管的 MCP 聚合器、编排器、中间件和网关，用于组合并治理工具服务器。
 - [Firecrawl](https://github.com/firecrawl/firecrawl)：Web 搜索、抓取、爬取与抽取 API，可将网页数据转换为适合 LLM 使用的 Markdown 和结构化输出。
 - [Crawl4AI](https://github.com/unclecode/crawl4ai)：面向 LLM 的开源 Web 爬虫与抓取工具，适合构建 RAG、Agent 和 Web 数据流水线。
 - [Jina Reader](https://github.com/jina-ai/reader)：URL 转 LLM 输入工具，通过简单前缀将任意网页转为清理后的 LLM 友好 Markdown 格式。
@@ -745,6 +746,7 @@ Infrastructure as Code，基础设施即代码，是通过代码而非手动流�
 
 信任很难，知道该信任谁更难。
 
+- [OpenFGA](https://github.com/openfga/openfga)：受 Google Zanzibar 启发的高性能授权引擎，支持细粒度、基于关系的访问控制。
 - [keycloak](https://github.com/keycloak/keycloak)：面向现代应用和服务的开源 IAM。
 - [OpenBao](https://github.com/openbao/openbao)：开源 Secret 管理系统，用于存储和分发密钥、证书与加密密钥。
 - [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy)：轻量级 OAuth2 反向代理，支持多种身份提供商和简单授权校验。


### PR DESCRIPTION
## Summary
- Add high-signal MCP gateway and authorization infrastructure entries to both README variants.

## Projects added
- MetaMCP
- OpenFGA

## Validation
- Markdown structural checks passed.
- English/Chinese GitHub URL parity passed (616 entries).
- `git diff --check` passed.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.
- Changed files limited to `README.md` and `README.zh-CN.md`.

## Risk
- Documentation-only; descriptions may require future refinement as project scope evolves.

## Auto-merge intent
- Self-review and checks required; merge automatically when checks are green or absent.