### PR TITLE
docs: clarify LLM observability gateway boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 **Production checklist:** Before adopting a tool, verify OpenTelemetry or an exportable trace format, retention and redaction controls, reproducible evaluation runs, framework coverage, and a clear path from an alert to the underlying prompt, tool call, model, and cost. A dashboard without failure evidence is just a very colorful shrug.
 
+**Gateway boundary:** Treat routing, rate limits, budgets, retries, and provider failover as gateway concerns; keep tracing, evaluation, and prompt or response analysis here only when they are the tool’s primary operational purpose. This avoids counting one gateway as three observability platforms with different hats.
+
 - [LiteLLM](https://github.com/BerriAI/litellm): OpenAI-compatible LLM gateway with routing, budgets, logging, and provider abstraction.
 - [Langfuse](https://github.com/langfuse/langfuse): Open-source LLM engineering platform for traces, prompt management, evaluations, and metrics.
 - [Litefuse](https://github.com/litefuse/litefuse): Open-source LLM engineering platform for collaboratively developing, monitoring, evaluating, and debugging AI applications with self-hosted deployment.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,6 +58,8 @@
 
 **生产检查清单：** 采用前确认工具支持 OpenTelemetry 或可导出的 trace 格式、保留与脱敏控制、可复现的评估运行、目标框架覆盖，以及从告警追溯到具体 Prompt、工具调用、模型和成本的清晰路径。只有仪表盘而没有失败证据，就像把生产事故换成了彩色壁纸。
 
+**网关边界：** 路由、限流、预算、重试和供应商故障转移应归入网关职责；只有当追踪、评估以及 Prompt/响应分析是工具的主要运维目的时，才放在本节。这样可以避免同一个网关换三顶帽子后被重复算成三个可观测平台。
+
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。
 - [Langfuse](https://github.com/langfuse/langfuse)：开源 LLM 工程平台，支持链路追踪、Prompt 管理、评估和指标分析。
 - [Litefuse](https://github.com/litefuse/litefuse)：开源 LLM 工程平台，支持协作开发、监控、评估和调试 AI 应用，并可自托管部署。


### PR DESCRIPTION
## Summary

Clarify the boundary between LLM/agent observability and AI gateway responsibilities in both README language variants.

## Content added

- English and Simplified Chinese guidance for classifying routing, budgets, retries, failover, tracing, evaluation, and prompt/response analysis.

## Validation

- `git diff --check`
- Markdown internal-link, duplicate-URL, and duplicate-entry checks
- Bilingual URL parity check
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD
- Self-review: changed files are limited to `README.md` and `README.zh-CN.md`, and the wording is semantically aligned

## Risk

Low: documentation-only guidance; no project links or runtime code changed.

## Auto-merge intent

Merge automatically after self-review if checks are green or absent. Do not bypass failing checks.
