### PR TITLE
docs: add AI agent sandbox runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Airweave](https://github.com/airweave-ai/airweave): Open-source context retrieval layer that syncs diverse data sources into searchable context for AI agents and applications.
 - [OpenSandbox](https://github.com/opensandbox-group/OpenSandbox): Secure, fast, and extensible sandbox runtime for isolating AI agent code and tool execution.
 - [Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox): Kubernetes API and controller for managing isolated, stateful, singleton workloads such as AI agent runtimes.
+- [KARS](https://github.com/Azure/kars): Microsoft’s Kubernetes reference stack for running AI agents with hardened per-agent sandboxes, governed egress, and encrypted inter-agent communication.
+- [Pullrun](https://github.com/pullrun/pullrun): AI agent sandbox runtime that boots OCI images in Firecracker microVMs, Linux containers, or Apple Silicon VMs with native MCP support.
 - [AgentOS](https://github.com/rivet-dev/agentos): Library that gives AI agents an operating-system-like runtime in an existing backend using WebAssembly and V8 isolates.
 - [Cua](https://github.com/trycua/cua): Open-source computer-use infrastructure with cross-platform drivers, fleets, and benchmarks for agent training, evaluation, and data generation.
 - [Apache Doris](https://github.com/apache/doris): Real-time analytics and hybrid-search database for AI agents and operational data workloads.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -370,6 +370,8 @@
 - [Airweave](https://github.com/airweave-ai/airweave)：开源上下文检索层，可将多种数据源同步为可搜索上下文，供 AI Agent 和应用使用。
 - [OpenSandbox](https://github.com/opensandbox-group/OpenSandbox)：安全、快速且可扩展的沙箱运行时，用于隔离 AI Agent 代码和工具执行。
 - [Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox)：用于管理隔离、有状态、单例工作负载的 Kubernetes API 与控制器，适合 AI Agent 运行时。
+- [KARS](https://github.com/Azure/kars)：Microsoft 面向 Kubernetes 的 AI Agent 参考栈，提供强化的 Agent 独立沙箱、受治理的出站流量和端到端加密的 Agent 间通信。
+- [Pullrun](https://github.com/pullrun/pullrun)：AI Agent 沙箱运行时，可在 Firecracker microVM、Linux 容器或 Apple Silicon VM 中启动 OCI 镜像，并原生支持 MCP。
 - [AgentOS](https://github.com/rivet-dev/agentos)：基于 WebAssembly 和 V8 isolate 的库，可在现有后端中为 AI Agent 提供类似操作系统的运行时。
 - [Cua](https://github.com/trycua/cua)：开源 computer-use 基础设施，提供跨平台驱动、设备集群和基准测试，用于 Agent 训练、评估和数据生成。
 - [Apache Doris](https://github.com/apache/doris)：面向 AI Agent 和运维数据工作负载的实时分析与混合搜索数据库。


### PR DESCRIPTION
## Summary
Add a focused set of production-oriented AI agent sandbox/runtime projects to the AI Infrastructure section in both README language variants.

## Projects added
- KARS
- Pullrun

## Validation
- Markdown internal-link and duplicate URL checks passed
- Bilingual URL parity passed
- git diff --check passed
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD
- Changed files limited to README.md and README.zh-CN.md

## Risk
Documentation-only; descriptions are concise and may need future correction if project scope or canonical repositories change.

## Auto-merge intent
Self-review first; merge with squash if the diff is expected and checks are green or absent.