### PR TITLE
docs: add Sage agent detection and response tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [AgentShield](https://github.com/affaan-m/agentshield): AI agent security scanner for detecting vulnerabilities in agent configurations, MCP servers, and tool permissions via CLI or GitHub Action.
 - [Crust](https://github.com/BakeLens/crust): Local AI-agent security gateway that intercepts tool calls and MCP/ACP traffic to block dangerous actions, scan secrets, and enforce runtime rules.
 - [Adrian](https://github.com/secureagentics/Adrian): Open-source runtime AI agent security tool that monitors and controls AI agents in real time, catching malicious tool use, prompt injection, and policy drift before the agent acts.
+- [Sage](https://github.com/gendigitalinc/sage): Lightweight Agent Detection & Response layer that guards AI-agent commands, files, and web requests.
 - [Doberman](https://github.com/fu351/Doberman-Core): Runtime guardrails and adaptive authorization for AI coding agents, with MCP or host-hook enforcement, approvals, audit logs, and fail-closed policy decisions.
 - [Agent3σ-Canary](https://github.com/antgroup/Agent3Sigma-Canary): Sandboxed framework for evaluating AI agent security in realistic tool-using workflows, with trajectory-based scoring across safety, awareness, and task utility.
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Toolkit for policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous AI agents.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -612,6 +612,7 @@
 - [AgentShield](https://github.com/affaan-m/agentshield)：AI Agent 安全扫描器，通过 CLI 或 GitHub Action 检测 Agent 配置、MCP Server 和工具权限中的漏洞。
 - [Crust](https://github.com/BakeLens/crust)：本地 AI Agent 安全网关，可拦截工具调用及 MCP/ACP 流量，阻止危险操作、扫描 Secret 并执行运行时规则。
 - [Adrian](https://github.com/secureagentics/Adrian)：开源 AI Agent 运行时安全工具，实时监控和控制 AI Agent，在 Agent 执行动作前拦截恶意工具调用、Prompt 注入和策略偏移。
+- [Sage](https://github.com/gendigitalinc/sage)：轻量级 Agent Detection & Response 层，用于保护 AI Agent 的命令、文件和 Web 请求。
 - [Doberman](https://github.com/fu351/Doberman-Core)：面向 AI 编码 Agent 的运行时护栏与自适应授权工具，通过 MCP 或主机 Hook 在执行前实施策略，提供审批、审计日志和默认拒绝机制。
 - [Agent3σ-Canary](https://github.com/antgroup/Agent3Sigma-Canary)：在沙箱化真实工具工作流中评估 AI Agent 安全性的框架，基于完整执行轨迹从安全结果、安全意识和任务效用等维度评分。
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)：用于自主 AI Agent 的策略执行、零信任身份、执行沙箱和可靠性工程工具包。


### PR DESCRIPTION
## Summary

- Add Sage to the Security and Supply Chain section in both README language variants.
- Describe its lightweight Agent Detection & Response coverage for commands, files, and web requests.

## Projects added

- Sage — https://github.com/gendigitalinc/sage (262 stars at discovery; Apache-2.0; active repository).

## Validation

- Markdown internal-link, duplicate URL/name, and bilingual parity checks passed.
- `git diff --check` passed.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; base is an ancestor of HEAD.

## Risk

- Low: documentation-only addition. Project claims are intentionally limited to the repository description.

## Auto-merge intent

- Self-review required; merge with squash only if the diff remains expected and checks are green or absent.