### PR TITLE
docs: add AI security and agent backend tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Stagehand](https://github.com/browserbase/stagehand): Open-source SDK for building browser agents with AI-powered web automation, extraction, and interaction at scale.
 - [FlagEmbedding](https://github.com/FlagOpen/FlagEmbedding): Open-source toolkit for embedding and reranking models (BGE series) powering retrieval-augmented LLM applications.
 - [Open WebUI](https://github.com/open-webui/open-webui): Self-hosted LLM chat interface with RAG, web search, tool integration, model management, and multi-user deployment for internal AI platforms.
+- [InsForge](https://github.com/InsForge/InsForge): Open-source backend platform for agentic coding that provides database, authentication, storage, compute, hosting, and an AI gateway for full-stack applications.
 - [Label Studio](https://github.com/HumanSignal/label-studio): Open-source data labeling platform for images, text, audio, video, and time series in ML and LLM training workflows.
 - [Argilla](https://github.com/argilla-io/argilla): Open-source collaboration platform for building, curating, and versioning high-quality datasets for LLM fine-tuning and evaluation.
 - [llmware](https://github.com/llmware-ai/llmware): Unified open-source framework for enterprise LLM applications with integrated RAG, parsing, embedding, and vector database orchestration.
@@ -651,6 +652,8 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Spring AI MCP Security](https://github.com/spring-ai-community/mcp-security): Spring AI security and authorization support for MCP clients, servers, and authorization servers, including OAuth 2.0 flows.
 - [mcp-context-protector](https://github.com/trailofbits/mcp-context-protector): Trail of Bits security wrapper for MCP servers with configuration pinning, tool-response quarantine, and prompt-injection defenses.
 - [Agent Scan](https://github.com/snyk/agent-scan): Security scanner for AI agents, MCP servers, and agent skills, designed to catch risks before agent components enter a workflow.
+- [Strix](https://github.com/usestrix/strix): Open-source AI penetration-testing tool that uses autonomous agents to discover and validate application vulnerabilities with proof-of-concept exploits.
+- [Shannon](https://github.com/KeygraphHQ/shannon): Autonomous AI pentester for web applications and APIs that combines source analysis with live exploit validation before vulnerabilities reach production.
 
 ## Platform Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -342,6 +342,7 @@
 - [Stagehand](https://github.com/browserbase/stagehand)：开源浏览器 Agent SDK，支持 AI 驱动的 Web 自动化、数据提取和大规模页面交互。
 - [FlagEmbedding](https://github.com/FlagOpen/FlagEmbedding)：开源嵌入与重排序模型工具包（BGE 系列），为检索增强 LLM 应用提供核心能力。
 - [Open WebUI](https://github.com/open-webui/open-webui)：自托管的 LLM 对话界面，集成 RAG、Web 搜索、工具调用、模型管理和多用户部署能力，适用于内部 AI 平台。
+- [InsForge](https://github.com/InsForge/InsForge)：面向 Agentic Coding 的开源后端平台，提供数据库、身份认证、存储、计算、托管和 AI 网关，支持端到端构建全栈应用。
 - [Label Studio](https://github.com/HumanSignal/label-studio)：开源数据标注平台，支持图像、文本、音频、视频和时序数据标注，适用于 ML 和 LLM 训练工作流。
 - [Argilla](https://github.com/argilla-io/argilla)：面向 AI 工程师和领域专家的开源协作平台，用于构建、管理和版本化 LLM 微调与评估所需的高质量数据集。
 - [llmware](https://github.com/llmware-ai/llmware)：统一的开源框架，用于构建企业级 LLM 应用，集成 RAG、文档解析、嵌入和向量数据库编排能力。
@@ -651,6 +652,8 @@
 - [Spring AI MCP Security](https://github.com/spring-ai-community/mcp-security)：为 Spring AI 的 MCP Client、Server 和授权服务器提供安全与授权支持，包括 OAuth 2.0 流程。
 - [mcp-context-protector](https://github.com/trailofbits/mcp-context-protector)：Trail of Bits 的 MCP Server 安全包装器，提供配置固定、工具响应隔离和 Prompt 注入防护。
 - [Agent Scan](https://github.com/snyk/agent-scan)：面向 AI Agent、MCP Server 和 Agent Skill 的安全扫描器，用于在组件进入工作流前发现风险。
+- [Strix](https://github.com/usestrix/strix)：开源 AI 渗透测试工具，使用自主 Agent 发现并验证应用漏洞，并生成可复现的概念验证利用结果。
+- [Shannon](https://github.com/KeygraphHQ/shannon)：面向 Web 应用和 API 的自主 AI 渗透测试工具，将源码分析与真实利用验证结合起来，在漏洞进入生产环境前发现问题。
 
 ## Platform Engineering 平台工程
 


### PR DESCRIPTION
## Summary
Add a small bilingual curation batch for production AI operations.

## Projects added
- Strix and Shannon to Security and Supply Chain for AI-assisted penetration testing and exploit validation.
- InsForge to AI Infrastructure for agentic full-stack backend operations.

## Validation
- Markdown internal-link, duplicate URL, and duplicate entry-name checks passed.
- English/Chinese project URLs and entries are aligned.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Changed files limited to README.md and README.zh-CN.md.

## Risk
Descriptions are concise curation summaries; security tools must still be evaluated in authorized environments and reviewed for operational fit.

## Auto-merge intent
Self-review and merge automatically if the diff is expected and checks are green or absent.