### PR TITLE
docs: add sandboxed agent evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [agentacct](https://github.com/mikehasa/agentacct): Local-first terminal dashboard that joins coding-agent session usage with recorded work steps, checks, provider limits, and estimated cost.
 - [agentglass](https://github.com/SirAllap/agentglass): Local-first cockpit for monitoring coding-agent sessions, tool calls, tokens, costs, and latency through hooks or OpenTelemetry, with optional approval controls.
 - [OpenTelemetry MCP Server](https://github.com/traceloop/opentelemetry-mcp-server): Unified MCP server for querying OpenTelemetry traces across Jaeger, Tempo, Traceloop, and other backends so AI agents can investigate distributed systems.
+- [Agent Diff](https://github.com/agent-diff-bench/agent-diff): Interactive, sandboxed replicas of third-party APIs for deterministic AI agent evaluation and reinforcement-learning experiments without external side effects.
+- [ClawLens](https://github.com/nk3750/clawlens): Local OpenClaw observability plugin with tool-call audit logs, risk scoring, live sessions, and operator-controlled guardrails.
 - [Opik MCP](https://github.com/comet-ml/opik-mcp): MCP server for reading Opik traces, logging evaluation scores, and managing prompts from AI coding clients.
 - [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay): Multi-language agent runtime and middleware library for managing execution scopes, lifecycle events, and tool or LLM call telemetry.
 - [Kitaru](https://github.com/zenml-io/kitaru): Production AI agent recording and replay toolkit for analyzing runs and improving agent behavior.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,6 +88,8 @@
 - [agentacct](https://github.com/mikehasa/agentacct)：本地优先的终端仪表盘，将编码 Agent 会话用量与记录的工作步骤、检查结果、供应商限额和成本估算关联起来。
 - [agentglass](https://github.com/SirAllap/agentglass)：本地优先的控制台，可通过 hooks 或 OpenTelemetry 监控编码 Agent 会话、工具调用、Token、成本和延迟，并提供可选的审批控制。
 - [OpenTelemetry MCP Server](https://github.com/traceloop/opentelemetry-mcp-server)：统一的 MCP Server，可查询 Jaeger、Tempo、Traceloop 等后端的 OpenTelemetry 链路，让 AI Agent 能够调查分布式系统。
+- [Agent Diff](https://github.com/agent-diff-bench/agent-diff)：提供第三方 API 的交互式沙箱副本，用于在无外部副作用的情况下对 AI Agent 进行确定性评估和强化学习实验。
+- [ClawLens](https://github.com/nk3750/clawlens)：面向 OpenClaw 的本地可观测性插件，提供工具调用审计日志、风险评分、实时会话和由运维人员控制的防护规则。
 - [Opik MCP](https://github.com/comet-ml/opik-mcp)：面向 AI 编码客户端的 MCP Server，可读取 Opik trace、记录评估分数并管理 Prompt。
 - [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay)：多语言 Agent 运行时与中间件库，用于管理执行作用域、生命周期事件以及工具或 LLM 调用遥测。
 - [Kitaru](https://github.com/zenml-io/kitaru)：面向生产环境的 AI Agent 录制与回放工具，用于分析运行过程并改进 Agent 行为。


### PR DESCRIPTION
## Summary
- Add three production-oriented AI agent evaluation/observability tools to both README language variants.

## Projects added
- Agent Diff: deterministic sandboxed third-party API environments for agent evaluation.
- ClawLens: local OpenClaw tool-call observability and guardrails.

## Validation
- `git diff --check`
- Markdown internal-link, duplicate URL/name, and bilingual URL-set checks passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Changed files are limited to `README.md` and `README.zh-CN.md`.

## Risk
- Documentation-only change; descriptions are concise and based on the projects' current repositories. Star counts were used as discovery signals, not committed to the README.

## Auto-merge intent
- Requesting maintainer review; do not auto-merge from this job.
