### PR TITLE
docs: add AI gateway production selection guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 **Gateway boundary:** Treat routing, rate limits, budgets, retries, and provider failover as gateway concerns; keep tracing, evaluation, and prompt or response analysis here only when they are the tool’s primary operational purpose. This avoids counting one gateway as three observability platforms with different hats.
 
+**Gateway selection guidance:** Choose the smallest control surface that covers provider abstraction, routing policy, quotas, retries, and auditability. Before production rollout, verify streaming behavior, timeout and fallback semantics, tenant isolation, secret rotation, cost attribution, and metrics or traces that remain useful when an upstream provider is degraded.
+
 - [LiteLLM](https://github.com/BerriAI/litellm): OpenAI-compatible LLM gateway with routing, budgets, logging, and provider abstraction.
 - [Langfuse](https://github.com/langfuse/langfuse): Open-source LLM engineering platform for traces, prompt management, evaluations, and metrics.
 - [Litefuse](https://github.com/litefuse/litefuse): Open-source LLM engineering platform for collaboratively developing, monitoring, evaluating, and debugging AI applications with self-hosted deployment.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,6 +62,8 @@
 
 **网关边界：** 路由、限流、预算、重试和供应商故障转移应归入网关职责；只有当追踪、评估以及 Prompt/响应分析是工具的主要运维目的时，才放在本节。这样可以避免同一个网关换三顶帽子后被重复算成三个可观测平台。
 
+**网关选择建议：** 选择能够覆盖供应商抽象、路由策略、配额、重试和审计的最小控制面。上线前确认流式响应、超时与故障转移语义、租户隔离、密钥轮换、成本归因，以及上游供应商降级时仍然有用的指标或 trace。
+
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。
 - [Langfuse](https://github.com/langfuse/langfuse)：开源 LLM 工程平台，支持链路追踪、Prompt 管理、评估和指标分析。
 - [Litefuse](https://github.com/litefuse/litefuse)：开源 LLM 工程平台，支持协作开发、监控、评估和调试 AI 应用，并可自托管部署。


### PR DESCRIPTION
## Summary

- Add production-focused AI gateway selection guidance to both README language variants.
- Cover provider abstraction, routing, quotas, retries, auditability, streaming, failover, tenant isolation, secret rotation, cost attribution, and degraded-upstream telemetry.

## Content added

- Bilingual gateway selection checklist under LLM and Agent Observability.

## Validation

- `git diff --check`
- Markdown internal-link and duplicate URL/name checks passed.
- English/Simplified Chinese supporting guidance parity verified.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Changed files limited to `README.md` and `README.zh-CN.md`.
- Remote branch SHA matches local HEAD.

## Risk

Documentation-only; no runtime behavior changes. The guidance is intentionally generic and should complement, not replace, project-specific load and failure testing.

## Auto-merge intent

Self-review passed. Auto-merge with squash if checks are green or absent.