### PR TITLE
docs: add RAG regression gate guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 **Production checklist:** Before adopting a tool, verify OpenTelemetry or an exportable trace format, retention and redaction controls, reproducible evaluation runs, framework coverage, and a clear path from an alert to the underlying prompt, tool call, model, and cost. A dashboard without failure evidence is just a very colorful shrug.
 
+**Regression gate:** Keep a small, versioned evaluation set in CI, compare retrieval and answer-quality metrics separately, and define rollback thresholds before changing prompts, models, retrievers, or gateway policies. “It looked good in the demo” is not a release strategy.
+
 **Operational evidence checklist:** For production rollouts, record the trace and evaluation schema, sampling and PII-redaction policy, owner for each alert, retention and replay limits, and the rollback trigger. If a tool cannot export evidence that another system can inspect, it is an integration risk—not just a missing checkbox.
 
 **Gateway boundary:** Treat routing, rate limits, budgets, retries, and provider failover as gateway concerns; keep tracing, evaluation, and prompt or response analysis here only when they are the tool’s primary operational purpose. This avoids counting one gateway as three observability platforms with different hats.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,8 @@
 
 **网关选择建议：** 选择能够覆盖供应商抽象、路由策略、配额、重试和审计的最小控制面。上线前确认流式响应、超时与故障转移语义、租户隔离、密钥轮换、成本归因，以及上游供应商降级时仍然有用的指标或 trace。
 
+**回归门禁：** 在 CI 中维护一组小而有版本控制的评估集，分别比较检索质量与回答质量，并在修改 Prompt、模型、检索器或网关策略前定义回滚阈值。“Demo 里看起来不错”不是发布策略。
+
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。
 - [Langfuse](https://github.com/langfuse/langfuse)：开源 LLM 工程平台，支持链路追踪、Prompt 管理、评估和指标分析。
 - [Litefuse](https://github.com/litefuse/litefuse)：开源 LLM 工程平台，支持协作开发、监控、评估和调试 AI 应用，并可自托管部署。


### PR DESCRIPTION
## Summary

- Add a bilingual regression-gate note to the LLM and Agent Observability section.
- Make RAG quality checks and rollback thresholds explicit before production changes.

## Content added

- Versioned evaluation set in CI.
- Separate retrieval and answer-quality comparisons.
- Rollback thresholds for prompts, models, retrievers, and gateway policies.

## Validation

- `markdown structural checks ok`
- `git diff --check`
- English and Simplified Chinese guidance added with equivalent meaning.
- Diff limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk

Low: documentation-only guidance; no runtime or dependency changes.

## Auto-merge intent

Auto-merge after self-review if the PR diff is limited to the expected bilingual README guidance and checks are green or absent.
