### PR TITLE
docs: clarify streaming operations for AI data flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,8 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 
 ### Streaming Operations
 
+Streaming systems provide the event transport and analytics foundation for telemetry, RAG refreshes, usage metering, and other continuously updated operational data flows.
+
 - [Kafbat UI](https://github.com/kafbat/kafka-ui): Open-source web UI for managing Apache Kafka clusters, topics, consumers, schemas, and Kafka Connect.
 - [Apache SeaTunnel](https://github.com/apache/seatunnel): Distributed data integration platform for high-volume batch and streaming data movement.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -487,8 +487,10 @@
 
 ### Streaming Operations 流式数据运维
 
+流式系统为遥测、RAG 刷新、用量计量和其他持续更新的运维数据流提供事件传输与分析基础。
+
 - [Kafbat UI](https://github.com/kafbat/kafka-ui)：开源 Web UI，用于管理 Apache Kafka 集群、Topic、消费者、Schema 和 Kafka Connect。
-- [Apache SeaTunnel](https://github.com/apache/seatunnel)：分布式数据集成平台，适合大规模批处理和流式数据传输。
+- [Apache SeaTunnel](https://github.com/apache/seatunnel)：分布式数据集成平台，支持高吞吐批处理和流式数据传输。
 
 ## FinOps
 


### PR DESCRIPTION
## Summary

- Clarify the role of streaming systems in the DataOps section.
- Keep the English and Simplified Chinese README variants aligned.

## Content added

- A concise purpose note covering telemetry, RAG refreshes, usage metering, and continuously updated operational data flows.
- A slightly more precise Chinese description for Apache SeaTunnel.

## Validation

- Markdown internal-link, duplicate URL, and duplicate entry-name checks passed.
- `git diff --check` passed.
- Changed files are limited to `README.md` and `README.zh-CN.md`.
- Rebased onto the latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk

Documentation-only wording change; no runtime or API behavior is affected.

## Auto-merge intent

Self-reviewed and safe to squash-merge if checks are green or absent.
