### PR TITLE
docs: add agent security audit benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,8 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner): Security scanner for MCP servers that identifies potential threats and security findings before agents depend on their tool integrations.
 - [OctoBus](https://github.com/chaitin/OctoBus): Local single-binary gateway for managing pluggable services and exposing selected capabilities through gRPC, Connect RPC, and MCP.
 - [OpenHack](https://github.com/openhackai/OpenHack): Open-source agentic security scanner and verifier for finding and validating vulnerabilities in codebases with open-source models.
+- [AgentStalker](https://github.com/Gach0ng/AgentStalker): End-to-end LLM agent security audit framework combining static modeling, attack synthesis, sandbox replay, MCP auditing, and evidence-backed reports.
+- [Agent Security Bench (ASB)](https://github.com/agiresearch/ASB): Research benchmark and attack framework for systematically evaluating adversarial attacks and defenses across LLM-based agent scenarios.
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard): OWASP project defining inspectable, traceable, and instrumentable observability practices for trustworthy AI agents.
 - [Agent Security Harness](https://github.com/msaleme/red-team-blue-team-agent-fabric): Executable security-testing harness for AI agents covering MCP, A2A, tool-use governance, and agentic supply-chain scenarios.
 - [Rogue](https://github.com/qualifire-dev/rogue): AI agent evaluation and red-team platform for regression testing, policy validation, adversarial probing, and security reporting across agent protocols.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -652,6 +652,8 @@
 - [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner)：MCP Server 安全扫描器，可在 Agent 依赖工具集成前识别潜在威胁和安全问题。
 - [OctoBus](https://github.com/chaitin/OctoBus)：本地单二进制网关，用于管理可插拔服务，并通过 gRPC、Connect RPC 和 MCP 暴露选定能力。
 - [OpenHack](https://github.com/openhackai/OpenHack)：开源 Agent 安全扫描与验证工具，使用开源模型在代码库中发现并验证安全漏洞。
+- [AgentStalker](https://github.com/Gach0ng/AgentStalker)：端到端 LLM Agent 安全审计框架，结合静态建模、攻击合成、沙箱回放、MCP 审计和基于证据的报告。
+- [Agent Security Bench (ASB)](https://github.com/agiresearch/ASB)：用于系统评估 LLM Agent 对抗性攻击与防御策略的研究基准和攻击框架，覆盖多类 Agent 场景。
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard)：OWASP 项目，为可信 AI Agent 定义可检查、可追踪和可插桩的可观测性实践。
 - [Agent Security Harness](https://github.com/msaleme/red-team-blue-team-agent-fabric)：面向 AI Agent 的可执行安全测试框架，覆盖 MCP、A2A、工具使用治理和 Agent 供应链场景。
 - [Rogue](https://github.com/qualifire-dev/rogue)：面向 AI Agent 的评估与红队平台，支持回归测试、策略校验、对抗性探测和跨 Agent 协议的安全报告。


### PR DESCRIPTION
## Summary

- Add AgentStalker and Agent Security Bench (ASB) to the Security and Supply Chain section.
- Keep the English and Simplified Chinese catalogs aligned.

## Projects added

- AgentStalker — end-to-end LLM agent security auditing with static modeling, attack synthesis, sandbox replay, MCP auditing, and evidence-backed reports.
- Agent Security Bench (ASB) — benchmark and attack framework for evaluating attacks and defenses in LLM-based agent scenarios.

## Validation

- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English/Chinese added-project parity check passed.
- `git diff --check` passed.
- Diff scope is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.

## Risk

Documentation-only change. The entries describe security testing and benchmarking tools; users should review each project's authorization and isolation requirements before running scans or attack scenarios.

## Auto-merge intent

Auto-merge after self-review and green or absent checks, per repository curation policy.
