### PR TITLE
docs: add iFixAi agent audit framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [MEDUSA](https://github.com/Pantheon-Security/medusa): AI-first security scanner for AI/ML applications, agents, MCP servers, and code, with supply-chain, prompt-injection, secret, and vulnerability detection.
 - [Arcjet JS](https://github.com/arcjet/arcjet-js): Runtime security SDK for AI applications and agents with prompt-injection detection, tool-call authorization, sensitive-data redaction, bot protection, and rate limiting.
 - [ADR](https://github.com/uber/ADR): Apache-2.0 agentic AI detection and response system combining agent telemetry, security benchmarking, and threat detection for enterprise AI agents.
+- [iFixAi](https://github.com/ifixai-ai/iFixAi): Apache-2.0 framework for independently auditing AI agents with reproducible inspections and scored reports across capability, reliability, safety, and operational behavior.
 - [MCP Security Checklist](https://github.com/slowmist/MCP-Security-Checklist): Practical security checklist for MCP hosts, clients, servers, multi-MCP deployments, and tool-ecosystem integrations.
 - [Google Security Operations MCP Server](https://github.com/google/mcp-security): Official MCP servers for integrating Google SecOps, Google Threat Intelligence, Security Command Center, and SOAR capabilities with AI assistants.
 - [Spring AI MCP Security](https://github.com/spring-ai-community/mcp-security): Spring AI security and authorization support for MCP clients, servers, and authorization servers, including OAuth 2.0 flows.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -662,6 +662,7 @@
 - [MEDUSA](https://github.com/Pantheon-Security/medusa)：面向 AI/ML 应用、Agent、MCP Server 和代码的 AI 原生安全扫描器，支持供应链、Prompt 注入、Secret 和漏洞检测。
 - [Arcjet JS](https://github.com/arcjet/arcjet-js)：面向 AI 应用和 Agent 的运行时安全 SDK，支持 Prompt 注入检测、工具调用授权、敏感数据脱敏、机器人防护和限流。
 - [ADR](https://github.com/uber/ADR)：基于 Apache-2.0 许可的 Agentic AI 检测与响应系统，将 Agent 遥测、安全基准测试和威胁检测结合起来，面向企业 AI Agent。
+- [iFixAi](https://github.com/ifixai-ai/iFixAi)：Apache-2.0 许可的 AI Agent 独立审计框架，通过可复现的检查项和评分报告评估 Agent 的能力、可靠性、安全性与运行行为。
 - [MCP Security Checklist](https://github.com/slowmist/MCP-Security-Checklist)：面向 MCP Host、Client、Server、多 MCP 部署和工具生态集成的实用安全检查清单。
 - [Google Security Operations MCP Server](https://github.com/google/mcp-security)：谷歌官方 MCP Server，用于将 Google SecOps、Google Threat Intelligence、Security Command Center 和 SOAR 能力接入 AI 助手。
 - [Spring AI MCP Security](https://github.com/spring-ai-community/mcp-security)：为 Spring AI 的 MCP Client、Server 和授权服务器提供安全与授权支持，包括 OAuth 2.0 流程。


### PR DESCRIPTION
## Summary
Add one production-oriented AI agent audit resource to both bilingual README files.

## Projects or content added
- iFixAi — an Apache-2.0 framework for independently auditing AI agents with reproducible inspections and scored reports.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English/Chinese parity verified; iFixAi appears once in each README with equivalent meaning.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased on latest `origin/main`; `origin/main` is an ancestor of the branch.
- Remote branch SHA matches local HEAD.
- Self-review: clean, expected docs-only diff.

## Risk
Low: documentation-only change. The project is third-party; users should review its inspection methodology and runtime assumptions before relying on audit scores.

## Auto-merge intent
Auto-merge after self-review and after checks are green or absent, using squash merge.
