### PR TITLE
docs: correct Rogue security repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [Agent Security Bench (ASB)](https://github.com/agiresearch/ASB): Research benchmark and attack framework for systematically evaluating adversarial attacks and defenses across LLM-based agent scenarios.
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard): OWASP project defining inspectable, traceable, and instrumentable observability practices for trustworthy AI agents.
 - [Agent Security Harness](https://github.com/msaleme/red-team-blue-team-agent-fabric): Executable security-testing harness for AI agents covering MCP, A2A, tool-use governance, and agentic supply-chain scenarios.
-- [Rogue](https://github.com/qualifire-dev/rogue): AI agent evaluation and red-team platform for regression testing, policy validation, adversarial probing, and security reporting across agent protocols.
+- [Rogue](https://github.com/rogue-security/rogue): AI agent evaluation and red-team platform for regression testing, policy validation, adversarial probing, and security reporting across agent protocols.
 - [Augustus](https://github.com/praetorian-inc/augustus): Apache-2.0 LLM security testing framework that detects prompt injection, jailbreaks, and adversarial weaknesses with 190+ probes across 28 model providers.
 - [SkillHub](https://github.com/iflytek/skillhub): Self-hosted registry for publishing and versioning agent skills with RBAC, audit logs, and Docker or Kubernetes deployment.
 - [MEDUSA](https://github.com/Pantheon-Security/medusa): AI-first security scanner for AI/ML applications, agents, MCP servers, and code, with supply-chain, prompt-injection, secret, and vulnerability detection.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -656,7 +656,7 @@
 - [Agent Security Bench (ASB)](https://github.com/agiresearch/ASB)：用于系统评估 LLM Agent 对抗性攻击与防御策略的研究基准和攻击框架，覆盖多类 Agent 场景。
 - [OWASP Agent Observability Standard](https://github.com/OWASP/www-project-agent-observability-standard)：OWASP 项目，为可信 AI Agent 定义可检查、可追踪和可插桩的可观测性实践。
 - [Agent Security Harness](https://github.com/msaleme/red-team-blue-team-agent-fabric)：面向 AI Agent 的可执行安全测试框架，覆盖 MCP、A2A、工具使用治理和 Agent 供应链场景。
-- [Rogue](https://github.com/qualifire-dev/rogue)：面向 AI Agent 的评估与红队平台，支持回归测试、策略校验、对抗性探测和跨 Agent 协议的安全报告。
+- [Rogue](https://github.com/rogue-security/rogue)：面向 AI Agent 的评估与红队平台，支持回归测试、策略校验、对抗性探测和跨 Agent 协议的安全报告。
 - [Augustus](https://github.com/praetorian-inc/augustus)：基于 Apache-2.0 许可的 LLM 安全测试框架，使用覆盖 28 个模型供应商的 190+ 探针检测 Prompt 注入、越狱和对抗性弱点。
 - [SkillHub](https://github.com/iflytek/skillhub)：自托管 Agent Skill 注册中心，支持发布、版本管理、RBAC、审计日志，以及 Docker 或 Kubernetes 部署。
 - [MEDUSA](https://github.com/Pantheon-Security/medusa)：面向 AI/ML 应用、Agent、MCP Server 和代码的 AI 原生安全扫描器，支持供应链、Prompt 注入、Secret 和漏洞检测。


### PR DESCRIPTION
## Summary
- Correct the Rogue repository link in both bilingual READMEs.
- Keep the security and supply-chain catalog aligned with the active canonical repository.

## Projects or content added
- Corrected `Rogue` from `qualifire-dev/rogue` to `rogue-security/rogue` in English and Simplified Chinese entries.

## Validation
- Markdown internal-link, duplicate URL/name, and bilingual parity checks passed.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Diff limited to `README.md` and `README.zh-CN.md`.

## Risk
- Documentation-only correction; no runtime impact. The canonical repository was verified as active and not archived (1,058 GitHub stars at discovery time).

## Auto-merge intent
- Self-review and merge automatically if the diff remains limited to the expected README files and checks are green or absent.
