### PR TITLE
docs: add AI inference rollout gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 
 **Selection guidance:** Separate the serving engine from the control plane: choose engines for throughput, latency, batching, and hardware support; choose operators and gateways for rollout safety, routing, quotas, autoscaling, and telemetry. Prefer projects with reproducible benchmarks and an explicit upgrade or rollback path.
 
+**Rollout gate:** Before shifting production traffic, record a baseline for throughput, tail latency, error rate, GPU utilization, and cost per request; canary model and runtime changes with representative prompts; and keep the previous artifact and routing policy ready for rollback. A faster token/sec number is not a release if the p99 or failure recovery got worse.
+
 - [GenAI Factory](https://github.com/GoogleCloudPlatform/genai-factory): Production-oriented blueprints for deploying generative AI infrastructure on Google Cloud with infrastructure as code and security best practices.
 - [GenAI on EKS Starter Kit](https://github.com/aws-samples/sample-genai-on-eks-starter-kit): Kubernetes deployment blueprint combining an AI gateway, LLM serving, vector databases, embedding models, and observability on Amazon EKS.
 - [Ray Serve](https://github.com/ray-project/ray): Scalable model serving library in Ray for building distributed online inference APIs and LLM serving workloads.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -238,6 +238,8 @@
 
 **选择建议：** 区分推理引擎与控制平面：推理引擎重点看吞吐、延迟、批处理和硬件支持；Operator 与网关重点看发布安全、路由、配额、自动扩缩容和遥测能力。优先选择提供可复现基准，以及明确升级和回滚路径的项目。
 
+**发布门禁：** 切换生产流量前，记录吞吐、尾延迟、错误率、GPU 利用率和单请求成本基线；用有代表性的 Prompt 对模型与运行时变更做金丝雀发布；并保留上一版制品和路由策略以便回滚。tokens/sec 更高不代表可以发布——如果 p99 或故障恢复变差，性能数字只是穿了西装的回归。
+
 - [GenAI Factory](https://github.com/GoogleCloudPlatform/genai-factory)：面向生产的生成式 AI 基础设施蓝图，使用基础设施即代码在 Google Cloud 上部署，并遵循安全最佳实践。
 - [GenAI on EKS Starter Kit](https://github.com/aws-samples/sample-genai-on-eks-starter-kit)：面向 Amazon EKS 的 Kubernetes 部署蓝图，整合 AI 网关、LLM 服务、向量数据库、Embedding 模型和可观测性组件。
 - [Ray Serve](https://github.com/ray-project/ray)：Ray 中的可扩展模型服务库，用于构建分布式在线推理 API 和 LLM 服务负载。


### PR DESCRIPTION
## Summary
Add bilingual production rollout guidance to the AI Serving and Inference Operations section.

## Content added
- English and Simplified Chinese rollout gates covering baseline metrics, canary traffic, representative prompts, and rollback artifacts.

## Validation
- Markdown internal-link and duplicate URL/name checks passed.
- `git diff --check` passed.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk
Documentation-only, low risk. The guidance adds operational safeguards without changing project entries or links.

## Auto-merge intent
Self-review is required. Merge with squash only if the expected diff is confirmed and checks are green or absent.
