### PR TITLE
docs: add Google ADK Java to agent workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Deep Agents](https://github.com/langchain-ai/deepagents): Batteries-included agent harness for long-running tasks with planning, subagents, filesystem access, and operational workflow composition.
 - [LongHorizon-Harness](https://github.com/AMAP-ML/LongHorizon-Harness): Loop-engineering harness for running Claude Code, Codex, and DeepSeek Harness across desktop apps and terminals with checkpoints, verification, recovery, and long-running task state.
 - [Google ADK JavaScript](https://github.com/google/adk-js): Code-first TypeScript toolkit for building, evaluating, and deploying AI agents with flexible orchestration and tool integration.
+- [Google ADK Java](https://github.com/google/adk-java): Code-first Java toolkit for building, evaluating, and deploying AI agents with flexible orchestration and tool integration.
 - [Ouroboros](https://github.com/Q00/ouroboros): Self-improving Agent OS with interview-gated, staged evaluation and budgeted evolution loops across 13 coding-agent runtimes including Claude Code, Codex, and Gemini CLI.
 
 ## DataOps

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -484,6 +484,7 @@
 - [Deep Agents](https://github.com/langchain-ai/deepagents)：开箱即用的 Agent Harness，面向长周期任务提供规划、子 Agent、文件系统访问和运维工作流编排能力。
 - [LongHorizon-Harness](https://github.com/AMAP-ML/LongHorizon-Harness)：面向循环工程的 Harness，可在桌面应用和终端中运行 Claude Code、Codex 与 DeepSeek Harness，并提供检查点、验证、恢复和长任务状态管理。
 - [Google ADK JavaScript](https://github.com/google/adk-js)：基于代码的 TypeScript 工具包，用于构建、评估和部署 AI Agent，支持灵活的编排与工具集成。
+- [Google ADK Java](https://github.com/google/adk-java)：基于代码的 Java 工具包，用于构建、评估和部署 AI Agent，支持灵活的编排与工具集成。
 - [Ouroboros](https://github.com/Q00/ouroboros)：自进化 Agent OS，提供面试门控的分阶段评估和预算化进化循环，支持 Claude Code、Codex、Gemini CLI 等 13 种编码 Agent 运行时。
 
 ## DataOps


### PR DESCRIPTION
## Summary

- Add Google ADK Java to the Agentic Workflow section in both README language variants.
- Record its code-first Java toolkit, evaluation, deployment, orchestration, and tool-integration scope.

## Projects / content added

- Google ADK Java — https://github.com/google/adk-java

## Validation

- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names, and bilingual URL-set parity.
- `git diff --check` passed.
- Rebased onto the latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Verified the pushed remote branch SHA matches local HEAD.

## Risk

- Documentation-only, two-line addition; no runtime or production behavior changes.
- GitHub star count was checked from the repository API (1,690 at curation time); stars are discovery context, not a quality guarantee.

## Auto-merge intent

- Requesting the repository's standard squash merge after self-review and green or absent checks.
