### PR TITLE
docs: add AI agent sandbox security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,8 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [Varlock](https://github.com/dmno-dev/varlock): AI-safe environment variable format that separates machine-readable schemas for agents from human-readable secrets, preventing accidental credential exposure in agent configs.
 - [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner): Security scanner for MCP servers that identifies potential threats and security findings before agents depend on their tool integrations.
 - [OctoBus](https://github.com/chaitin/OctoBus): Local single-binary gateway for managing pluggable services and exposing selected capabilities through gRPC, Connect RPC, and MCP.
+- [yoloAI](https://github.com/kstenerud/yoloai): Sandboxed runner for AI coding agents with disposable project copies, controlled credentials and network access, reviewable diffs, and selectable isolation backends.
+- [Sandbox0](https://github.com/sandbox0-ai/sandbox0): Kubernetes-native runtime for persistent, encrypted AI-agent sandboxes with durable rootfs checkpoints, gVisor support, and separated storage and compute.
 - [OpenHack](https://github.com/openhackai/OpenHack): Open-source agentic security scanner and verifier for finding and validating vulnerabilities in codebases with open-source models.
 - [AgentStalker](https://github.com/Gach0ng/AgentStalker): End-to-end LLM agent security audit framework combining static modeling, attack synthesis, sandbox replay, MCP auditing, and evidence-backed reports.
 - [Agent Security Bench (ASB)](https://github.com/agiresearch/ASB): Research benchmark and attack framework for systematically evaluating adversarial attacks and defenses across LLM-based agent scenarios.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -682,6 +682,8 @@
 - [Varlock](https://github.com/dmno-dev/varlock)：AI 安全的环境变量格式，将面向 Agent 的机器可读 Schema 与面向人类的 Secret 分离，防止 Agent 配置中的凭据意外泄露。
 - [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner)：MCP Server 安全扫描器，可在 Agent 依赖工具集成前识别潜在威胁和安全问题。
 - [OctoBus](https://github.com/chaitin/OctoBus)：本地单二进制网关，用于管理可插拔服务，并通过 gRPC、Connect RPC 和 MCP 暴露选定能力。
+- [yoloAI](https://github.com/kstenerud/yoloai)：面向 AI 编码 Agent 的沙箱运行器，提供项目副本隔离、受控凭据与网络访问、可审查 diff，以及可选的隔离后端。
+- [Sandbox0](https://github.com/sandbox0-ai/sandbox0)：Kubernetes 原生的持久化加密 AI Agent 沙箱运行时，支持持久 rootfs checkpoint、gVisor，以及存储与计算分离。
 - [OpenHack](https://github.com/openhackai/OpenHack)：开源 Agent 安全扫描与验证工具，使用开源模型在代码库中发现并验证安全漏洞。
 - [AgentStalker](https://github.com/Gach0ng/AgentStalker)：端到端 LLM Agent 安全审计框架，结合静态建模、攻击合成、沙箱回放、MCP 审计和基于证据的报告。
 - [Agent Security Bench (ASB)](https://github.com/agiresearch/ASB)：用于系统评估 LLM Agent 对抗性攻击与防御策略的研究基准和攻击框架，覆盖多类 Agent 场景。


### PR DESCRIPTION
## Summary
- Add yoloAI and Sandbox0 to the Security and Supply Chain section in both README variants.
- Cover disposable local agent sandboxes and persistent Kubernetes-native sandboxes as production AI security foundations.

## Projects added
- [yoloAI](https://github.com/kstenerud/yoloai)
- [Sandbox0](https://github.com/sandbox0-ai/sandbox0)

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese GitHub URL sets match (676 each).
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA matches local HEAD.

## Risk
- Documentation-only change; project maturity and security claims may evolve, so maintainers should re-check upstream release and threat-model details during review.

## Auto-merge intent
- Self-review before merge; squash-merge only if the expected two-file diff remains clean and checks are green or absent.