### PR TITLE
docs: expand production RAG knowledge platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,10 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Semantica](https://github.com/semantica-agi/semantica): Graph-native infrastructure for connecting context, knowledge, and accountable evidence in AI systems.
 - [Cognee](https://github.com/topoteretes/cognee): Open-source AI memory platform that gives agents persistent long-term memory through a self-hosted knowledge graph and vector database engine.
 - [OpenViking](https://github.com/volcengine/OpenViking): Self-evolving context database for AI agents that unifies agent memory, knowledge RAG, and skills into a single retrieval surface.
+- [DocsGPT](https://github.com/arc53/DocsGPT): Self-hosted private AI platform for enterprise search, document analysis, agent building, and multi-model assistants.
+- [LLM Wiki](https://github.com/nashsu/llm_wiki): Cross-platform document workspace that incrementally builds an organized, interconnected knowledge base instead of re-answering from scratch on every query.
+- [SurfSense](https://github.com/MODSetter/SurfSense): Open-source NotebookLM alternative for researching live web sources through a self-hosted application, API, or MCP server.
+- [Vespa](https://github.com/vespa-engine/vespa): Production AI search and serving platform for combining vector, lexical, and structured retrieval with real-time ranking and recommendations.
 
 ## Agentic Workflow
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -433,6 +433,10 @@
 - [Semantica](https://github.com/semantica-agi/semantica)：面向 AI 系统的图原生基础设施，用于连接上下文、知识与可审计的证据。
 - [Cognee](https://github.com/topoteretes/cognee)：开源 AI 记忆平台，通过自托管知识图谱和向量数据库引擎为 Agent 提供跨会话的持久长期记忆。
 - [OpenViking](https://github.com/volcengine/OpenViking)：面向 AI Agent 的自进化上下文数据库，将 Agent 记忆、知识 RAG 和技能统一到一个检索入口。
+- [DocsGPT](https://github.com/arc53/DocsGPT)：可自托管的私有 AI 平台，支持企业搜索、文档分析、Agent 构建和多模型助手。
+- [LLM Wiki](https://github.com/nashsu/llm_wiki)：跨平台文档工作区，可持续构建结构化、互联的知识库，避免每次查询都从头进行 RAG 问答。
+- [SurfSense](https://github.com/MODSetter/SurfSense)：开源 NotebookLM 替代方案，可通过自托管应用、API 或 MCP 服务研究实时 Web 来源。
+- [Vespa](https://github.com/vespa-engine/vespa)：生产级 AI 搜索与服务平台，将向量、词法和结构化检索与实时排序、推荐结合起来。
 
 ## Agentic Workflow 智能体工作流
 


### PR DESCRIPTION
## Summary
Expand the LLM Knowledge map with four actively maintained production-oriented projects covering private enterprise search, persistent knowledge workspaces, live-web research, and hybrid AI search.

## Projects added
- DocsGPT
- LLM Wiki
- SurfSense
- Vespa

## Validation
- Markdown internal-link and duplicate URL/name checks passed.
- English/Chinese project-set parity passed.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.
- Self-review: changed files are limited to README.md and README.zh-CN.md; descriptions are concise and semantically aligned.

## Risk
Documentation-only change. Star counts and repository activity were checked during discovery; they are signals, not quality guarantees.

## Auto-merge intent
Merge automatically after self-review when checks are green or absent; do not bypass failing checks.