### PR TITLE
docs: add FailproofAI to agent observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [PandaProbe](https://github.com/chirpz-ai/pandaprobe): Open-source agent engineering platform for traces, evaluations, and metrics across LangGraph, CrewAI, Claude Agent SDK, and other agent runtimes.
 - [Claude Tap](https://github.com/liaohch3/claude-tap): Local trace viewer that intercepts and inspects coding-agent API traffic from Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, and other clients.
 - [Grafana Agento11y](https://github.com/grafana/agento11y): Grafana's practical AI observability project for collecting useful telemetry from agent and LLM workflows.
+- [FailproofAI](https://github.com/FailproofAI/failproofai): Observability and policy enforcement for AI-agent harnesses, with run capture, runtime reliability checks, and a local dashboard.
 - [Agent Beacon](https://github.com/Asymptote-Labs/agent-beacon): Unified telemetry layer for AI agents running locally, in CI, or in the cloud, with a local dashboard and security-team workflows.
 - [dt-evals](https://github.com/dynatrace-oss/dt-evals): Apache-2.0 CLI with evaluators for AI applications and agents, including LLM-as-a-judge workflows that support observability feedback loops.
 - [EfficientAI](https://github.com/EfficientAI-tech/efficientAI): Open-source voice AI evaluation platform for testing, comparing, and shipping reliable voice agents.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -569,6 +569,7 @@
 - [Traccia](https://github.com/traccia-ai/traccia-py)：基于 OpenTelemetry 的 Python SDK，支持 AI Agent 追踪、Token 与成本统计、护栏检测、治理证据和 OTLP 导出。
 - [PandaProbe](https://github.com/chirpz-ai/pandaprobe)：开源 Agent 工程平台，面向 LangGraph、CrewAI、Claude Agent SDK 等运行时提供链路、评估和指标能力。
 - [Claude Tap](https://github.com/liaohch3/claude-tap)：本地 trace 查看器，可拦截和检查 Claude Code、Codex CLI、Gemini CLI、Cursor CLI、OpenCode 等编码 Agent 的 API 流量。
+- [FailproofAI](https://github.com/FailproofAI/failproofai)：面向 AI Agent Harness 的可观测性与策略执行工具，支持记录每次运行、检查运行时可靠性，并提供本地仪表板。
 - [Grafana Agento11y](https://github.com/grafana/agento11y)：Grafana 的实用型 AI 可观测性项目，用于采集 Agent 和 LLM 工作流的有效遥测数据。
 - [Agent Beacon](https://github.com/Asymptote-Labs/agent-beacon)：面向本地、CI 和云端 AI Agent 的统一遥测层，并提供本地仪表盘和面向安全团队的工作流。
 - [dt-evals](https://github.com/dynatrace-oss/dt-evals)：Apache-2.0 许可的 AI 应用与 Agent 评估 CLI，包含 LLM-as-a-judge 评估器，可接入可观测性反馈闭环。


### PR DESCRIPTION
## Summary
Add FailproofAI to the bilingual agent observability catalog.

## Projects or content added
- FailproofAI — observability and policy enforcement for AI-agent harnesses.

## Validation
- Markdown internal-link, duplicate URL, and duplicate entry-name checks passed.
- English/Chinese project parity passed.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Changed files limited to README.md and README.zh-CN.md.

## Risk
Documentation-only; project description is concise and based on the repository metadata checked during curation.

## Auto-merge intent
Self-review then squash merge if checks are green or absent.