### PR TITLE
docs: add Yuxi to LLM knowledge platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [LLM Wiki](https://github.com/nashsu/llm_wiki): Cross-platform document workspace that incrementally builds an organized, interconnected knowledge base instead of re-answering from scratch on every query.
 - [SurfSense](https://github.com/MODSetter/SurfSense): Open-source NotebookLM alternative for researching live web sources through a self-hosted application, API, or MCP server.
 - [Vespa](https://github.com/vespa-engine/vespa): Production AI search and serving platform for combining vector, lexical, and structured retrieval with real-time ranking and recommendations.
+- [Yuxi](https://github.com/xerrors/Yuxi): Self-hosted, multi-tenant knowledge-agent platform combining RAG, knowledge graphs, multi-agent workflows, MCP/Skills, sandboxing, and access control.
 
 ## Agentic Workflow
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -437,6 +437,7 @@
 - [LLM Wiki](https://github.com/nashsu/llm_wiki)：跨平台文档工作区，可持续构建结构化、互联的知识库，避免每次查询都从头进行 RAG 问答。
 - [SurfSense](https://github.com/MODSetter/SurfSense)：开源 NotebookLM 替代方案，可通过自托管应用、API 或 MCP 服务研究实时 Web 来源。
 - [Vespa](https://github.com/vespa-engine/vespa)：生产级 AI 搜索与服务平台，将向量、词法和结构化检索与实时排序、推荐结合起来。
+- [Yuxi](https://github.com/xerrors/Yuxi)：可自托管的多租户知识智能体平台，整合 RAG、知识图谱、多 Agent 工作流、MCP/Skills、沙箱和访问控制。
 
 ## Agentic Workflow 智能体工作流
 


### PR DESCRIPTION
## Summary

- Add Yuxi to the LLM Knowledge section in both README language variants.
- Describe its self-hosted multi-tenant RAG, knowledge graph, multi-agent, MCP/Skills, sandbox, and access-control capabilities.

## Projects / content added

- [Yuxi](https://github.com/xerrors/Yuxi)

## Validation

- Markdown structural checks passed for internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese entries are present with equivalent meaning.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Diff is limited to `README.md` and `README.zh-CN.md`.

## Risk

- Documentation-only change; low runtime risk.
- Project capabilities and popularity can change; maintainers should recheck the entry during future curation.

## Auto-merge intent

- Self-reviewed; merge automatically after PR checks are green or absent.
