### PR TITLE
docs: add LoopX agent control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 ## Agentic Workflow
 
 - [Paperclip](https://github.com/paperclipai/paperclip): Open-source control plane for coordinating teams of AI agents with goals, org charts, approvals, budgets, persistent work, and audit trails.
+- [LoopX](https://github.com/huangruiteng/loopx): Provider-neutral, local-first control plane for long-horizon agents with durable state, governance, recovery, evidence, and human-agent collaboration.
 - [AutoGPT](https://github.com/Significant-Gravitas/Auto-GPT): Autonomous AI agent framework that can break down and execute complex tasks.
 - [Atmosphere](https://github.com/Atmosphere/atmosphere): Portable JVM agent runtime that unifies model providers and agent frameworks with streaming, tool calls, human approvals, governance, and MCP or A2A support.
 - [Google AX](https://github.com/google/ax): Open-source distributed agent runtime for coordinating agent applications across scalable execution environments.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -442,6 +442,7 @@
 ## Agentic Workflow 智能体工作流
 
 - [Paperclip](https://github.com/paperclipai/paperclip)：用于协调 AI Agent 团队的开源控制平面，提供目标、组织结构、审批、预算、持久化工作流和审计追踪。
+- [LoopX](https://github.com/huangruiteng/loopx)：面向长周期 Agent 的供应商无关、本地优先控制平面，提供持久状态、治理、恢复、证据记录和人机协作。
 - [AutoGPT](https://github.com/Significant-Gravitas/Auto-GPT)：自主 AI Agent 框架，能够分解并执行复杂任务。
 - [Atmosphere](https://github.com/Atmosphere/atmosphere)：面向 JVM 的可移植 Agent 运行时，通过统一接口整合模型提供商和 Agent 框架，并支持流式输出、工具调用、人工审批、治理以及 MCP/A2A。
 - [Google AX](https://github.com/google/ax)：开源分布式 Agent 运行时，用于在可扩展的执行环境中协调 Agent 应用。


### PR DESCRIPTION
## Summary

- Add LoopX to the Agentic Workflow section in both English and Simplified Chinese.
- Describe its provider-neutral, local-first control-plane capabilities for long-horizon agents.

## Projects added

- LoopX — https://github.com/huangruiteng/loopx

## Validation

- `git diff --check`
- Markdown internal-link, duplicate URL/name, and bilingual GitHub URL parity checks passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Confirmed the pushed remote branch SHA matches local HEAD.
- Self-review: changed files are limited to `README.md` and `README.zh-CN.md`; entries are semantically aligned.

## Risk

Documentation-only, low risk. LoopX is an actively maintained Apache-2.0 project; its repository reports 5,006 GitHub stars and a push on 2026-08-21 at curation time. The description is intentionally concise and may need refinement as the project evolves.

## Auto-merge intent

Merge automatically after PR self-review and green or absent checks; do not bypass failing checks.