### PR TITLE
docs: add OxyGent multi-agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Microsoft Agent Framework](https://github.com/microsoft/agent-framework): MIT-licensed framework for building, orchestrating, and deploying AI agents and multi-agent workflows across Python and .NET.
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python): Lightweight Python framework for multi-agent workflows with tools, handoffs, guardrails, and tracing-oriented runtime patterns.
 - [Strands Agents Harness SDK](https://github.com/strands-agents/harness-sdk): Apache-2.0 SDK for building and controlling production AI-agent harnesses in Python and TypeScript across models and clouds.
+- [OxyGent](https://github.com/jd-opensource/OxyGent): Modular, observable, and evolvable multi-agent framework with a unified abstraction for composing production agent systems.
 - [Deep Agents](https://github.com/langchain-ai/deepagents): Batteries-included agent harness for long-running tasks with planning, subagents, filesystem access, and operational workflow composition.
 - [LongHorizon-Harness](https://github.com/AMAP-ML/LongHorizon-Harness): Loop-engineering harness for running Claude Code, Codex, and DeepSeek Harness across desktop apps and terminals with checkpoints, verification, recovery, and long-running task state.
 - [Google ADK JavaScript](https://github.com/google/adk-js): Code-first TypeScript toolkit for building, evaluating, and deploying AI agents with flexible orchestration and tool integration.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -492,6 +492,7 @@
 - [Microsoft Agent Framework](https://github.com/microsoft/agent-framework)：MIT 许可的 AI Agent 框架，支持使用 Python 和 .NET 构建、编排和部署 AI Agent 及多 Agent 工作流。
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python)：轻量级 Python 多 Agent 工作流框架，提供工具调用、交接、护栏和面向追踪的运行时能力。
 - [Strands Agents Harness SDK](https://github.com/strands-agents/harness-sdk)：Apache-2.0 许可的 SDK，用于在 Python 和 TypeScript 中构建并控制跨模型、跨云的生产级 AI Agent Harness。
+- [OxyGent](https://github.com/jd-opensource/OxyGent)：模块化、可观测且可演进的多 Agent 框架，通过统一抽象组合生产级 Agent 系统。
 - [Deep Agents](https://github.com/langchain-ai/deepagents)：开箱即用的 Agent Harness，面向长周期任务提供规划、子 Agent、文件系统访问和运维工作流编排能力。
 - [LongHorizon-Harness](https://github.com/AMAP-ML/LongHorizon-Harness)：面向循环工程的 Harness，可在桌面应用和终端中运行 Claude Code、Codex 与 DeepSeek Harness，并提供检查点、验证、恢复和长任务状态管理。
 - [Google ADK JavaScript](https://github.com/google/adk-js)：基于代码的 TypeScript 工具包，用于构建、评估和部署 AI Agent，支持灵活的编排与工具集成。


### PR DESCRIPTION
## Summary
- Add OxyGent to the Agentic Workflow catalog in both README variants.

## Projects or content added
- OxyGent — modular, observable, and evolvable multi-agent framework.

## Validation
- Markdown internal-link, duplicate URL/name, bilingual parity, and whitespace checks passed.
- Diff limited to README.md and README.zh-CN.md.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD; remote SHA matches local HEAD.

## Risk
- Documentation-only change; project maturity and API compatibility should be rechecked during future curation.

## Auto-merge intent
- Self-review before merge; merge automatically if the diff remains expected and checks are green or absent.