### PR TITLE
docs: add PyRIT to AI security operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [Agent3σ-Canary](https://github.com/antgroup/Agent3Sigma-Canary): Sandboxed framework for evaluating AI agent security in realistic tool-using workflows, with trajectory-based scoring across safety, awareness, and task utility.
 - [AgentDojo](https://github.com/ethz-spylab/agentdojo): Dynamic environment for evaluating attacks and defenses against LLM agents in realistic tool-use workflows.
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Toolkit for policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous AI agents.
+- [PyRIT](https://github.com/microsoft/PyRIT): Open-source framework for proactively identifying and testing generative AI risks through configurable red-team attack strategies.
 - [Open Agent Auth](https://github.com/alibaba/open-agent-auth): Enterprise framework for agent-operation authorization with cryptographic identity binding, fine-grained permissions, and semantic audit trails.
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector): Security scanner for AI agent skills that detects vulnerabilities, malicious patterns, and other security risks.
 - [CodeInspectus](https://github.com/Synvoya/codeinspectus): Local-first MCP server and CLI that combines SAST, secret, dependency, and AI-code-specific checks into a scan-fix-rescan workflow for AI-generated applications.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -674,7 +674,8 @@
 - [Agent3σ-Canary](https://github.com/antgroup/Agent3Sigma-Canary)：在沙箱化真实工具工作流中评估 AI Agent 安全性的框架，基于完整执行轨迹从安全结果、安全意识和任务效用等维度评分。
 - [AgentDojo](https://github.com/ethz-spylab/agentdojo)：用于在真实工具调用工作流中评估 LLM Agent 攻击与防御能力的动态环境。
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)：用于自主 AI Agent 的策略执行、零信任身份、执行沙箱和可靠性工程工具包。
-- [Open Agent Auth](https://github.com/alibaba/open-agent-auth)：面向企业 Agent 操作授权的框架，支持加密身份绑定、细粒度权限和语义审计轨迹。
+- [PyRIT](https://github.com/microsoft/PyRIT)：开源生成式 AI 风险识别框架，通过可配置的红队攻击策略主动发现和测试 AI 系统风险。
+- [Open Agent Auth](https://github.com/alibaba/open-agent-auth)：企业级 Agent 操作授权框架，支持加密身份绑定、细粒度权限和语义审计轨迹。
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector)：AI Agent Skill 安全扫描器，用于检测漏洞、恶意模式和其他安全风险。
 - [CodeInspectus](https://github.com/Synvoya/codeinspectus)：本地优先的 MCP Server 与 CLI，将 SAST、Secret、依赖和 AI 代码专项检查整合为面向 AI 生成应用的扫描、修复、复扫工作流。
 - [DefenseClaw](https://github.com/cisco-ai-defense/defenseclaw)：面向 Agentic AI 安全的开源治理工具包，用于评估和控制自主 AI 系统中的风险。


### PR DESCRIPTION
## Summary
- Add PyRIT to the Security and Supply Chain section in both README language variants.
- Position PyRIT as a configurable red-team framework for proactively identifying generative AI risks.

## Projects or content added
- [PyRIT](https://github.com/microsoft/PyRIT)

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese GitHub URL sets are identical (687 entries).
- `git diff --check` passed.
- `git diff --name-only origin/main...HEAD` contains only `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Verified the upstream repository is active, non-archived, MIT-licensed, and its canonical GitHub API record is reachable.

## Risk
- Documentation-only change; low runtime risk. PyRIT belongs in the AI security/red-team portion of the list and should not be treated as a general observability tool.

## Auto-merge intent
- Requesting the repository's default squash merge after PR self-review and green or absent checks. Do not bypass failing checks.
