### PR TITLE
docs: add EvalOps release gate guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 
 **Regression gate:** Keep a small, versioned evaluation set in CI, compare retrieval and answer-quality metrics separately, and define rollback thresholds before changing prompts, models, retrievers, or gateway policies. “It looked good in the demo” is not a release strategy.
 
+**EvalOps selection guidance:** Prefer evaluation tools that separate retrieval, generation, tool-use, safety, latency, and cost signals; support fixed datasets plus sampled production traces; and emit machine-readable results for CI or release gates. LLM-as-a-judge is useful evidence, not ground truth—pin the judge model and rubric, sample human review, and keep failed cases replayable.
+
 **Operational evidence checklist:** For production rollouts, record the trace and evaluation schema, sampling and PII-redaction policy, owner for each alert, retention and replay limits, and the rollback trigger. If a tool cannot export evidence that another system can inspect, it is an integration risk—not just a missing checkbox.
 
 **Gateway boundary:** Treat routing, rate limits, budgets, retries, and provider failover as gateway concerns; keep tracing, evaluation, and prompt or response analysis here only when they are the tool’s primary operational purpose. This avoids counting one gateway as three observability platforms with different hats.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,6 +66,8 @@
 
 **回归门禁：** 在 CI 中维护一组小而有版本控制的评估集，分别比较检索质量与回答质量，并在修改 Prompt、模型、检索器或网关策略前定义回滚阈值。“Demo 里看起来不错”不是发布策略。
 
+**EvalOps 选择建议：** 优先选择能区分检索、生成、工具调用、安全性、延迟和成本信号，并同时支持固定数据集与生产轨迹采样的评估工具；结果应能以机器可读格式接入 CI 或发布门禁。LLM-as-a-judge 是证据，不是真理——应固定裁判模型和评分标准，抽样进行人工复核，并保留失败案例以便重放。
+
 - [LiteLLM](https://github.com/BerriAI/litellm)：兼容 OpenAI API 的 LLM 网关，支持路由、预算、日志和多模型供应商抽象。
 - [Langfuse](https://github.com/langfuse/langfuse)：开源 LLM 工程平台，支持链路追踪、Prompt 管理、评估和指标分析。
 - [Litefuse](https://github.com/litefuse/litefuse)：开源 LLM 工程平台，支持协作开发、监控、评估和调试 AI 应用，并可自托管部署。


### PR DESCRIPTION
## Summary
- Added bilingual EvalOps selection guidance to the LLM and Agent Observability section.

## Content added
- Release-gate guidance for retrieval, generation, tool-use, safety, latency, cost, fixed datasets, sampled traces, and judge-model controls.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; origin/main is an ancestor of HEAD.
- Changed files are limited to README.md and README.zh-CN.md.
- PR self-review: bilingual meaning aligned; no blocking issues found.

## Risk
- Documentation-only, low runtime risk. Guidance is intentionally concise and does not prescribe a specific vendor or evaluator.

## Auto-merge intent
- Merge automatically after self-review when checks are green or absent.