### PR TITLE
docs: add ClawMetry agent runtime observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [LangWatch](https://github.com/langwatch/langwatch): Open-source platform for LLM monitoring, evaluations, traces, and agent testing.
 - [ClaudeSec](https://github.com/aanjaneyasinghdhoni/ClaudeSec): Fully local observability and security dashboard for AI coding agents, with OpenTelemetry traces, command auditing, threat detection, and optional enforcement.
 - [Opik](https://github.com/comet-ml/opik): Open-source platform for tracing, evaluating, and monitoring LLM applications, RAG systems, and agent workflows.
+- [ClawMetry](https://github.com/vivekchand/clawmetry): Local-first observability and governance dashboard for 26 AI agent runtimes, with sessions, tool calls, token costs, alerts, approvals, and OpenTelemetry export.
 - [Exgentic](https://github.com/Exgentic/exgentic): General agent evaluation framework for standardized, reproducible testing across agents, benchmarks, and domains.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Open-source CLI and platform for prompt testing, LLM evaluations, red teaming, and CI/CD regression checks.
 - [Langtrace](https://github.com/Scale3-Labs/langtrace): OpenTelemetry-based observability platform for tracing, evaluating, and monitoring LLM applications.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,6 +84,7 @@
 - [LangWatch](https://github.com/langwatch/langwatch)：开源平台，支持 LLM 监控、评估、链路追踪和 Agent 测试。
 - [ClaudeSec](https://github.com/aanjaneyasinghdhoni/ClaudeSec)：面向 AI 编码 Agent 的全本地可观测与安全仪表盘，支持 OpenTelemetry trace、命令审计、威胁检测和可选的运行时执行控制。
 - [Opik](https://github.com/comet-ml/opik)：开源平台，用于追踪、评估和监控 LLM 应用、RAG 系统与 Agent 工作流。
+- [ClawMetry](https://github.com/vivekchand/clawmetry)：本地优先的 AI Agent 可观测与治理仪表盘，支持 26 种 Agent 运行时、会话、工具调用、Token 成本、告警、审批和 OpenTelemetry 导出。
 - [Exgentic](https://github.com/Exgentic/exgentic)：通用 Agent 评估框架，用于跨 Agent、基准和领域进行标准化、可复现的测试。
 - [promptfoo](https://github.com/promptfoo/promptfoo)：开源 CLI 与平台，用于 Prompt 测试、LLM 评估、红队测试和 CI/CD 回归检查。
 - [Langtrace](https://github.com/Scale3-Labs/langtrace)：基于 OpenTelemetry 的可观测平台，用于追踪、评估和监控 LLM 应用。


### PR DESCRIPTION
## Summary
- Add ClawMetry to the LLM and Agent Observability catalog in both README variants.
- Describe its local-first runtime coverage, governance signals, approvals, and OpenTelemetry export.

## Projects or content added
- ClawMetry — https://github.com/vivekchand/clawmetry

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- English and Simplified Chinese GitHub URL sets match (695 each).
- `git diff --check` passed.
- Diff is limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.
- Self-review: bilingual entry meaning and category fit verified; no blocking issue found.

## Risk
- Documentation-only change; low operational risk. ClawMetry has a mixed open-source/paid feature model, so the entry intentionally describes the observable OSS capabilities without implying all runtimes or governance features are free.

## Auto-merge intent
- Merge automatically after self-review and when checks are green or absent; do not bypass failing checks.