### PR TITLE
docs: add agent telemetry conventions to observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Ragas](https://github.com/explodinggradients/ragas): Evaluation framework for RAG pipelines and LLM applications.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix): Open-source observability and evaluation platform for LLM, RAG, and ML systems.
 - [OpenInference](https://github.com/Arize-ai/openinference): OpenTelemetry instrumentation and semantic conventions for tracing LLM, RAG, and agent applications.
+- [Agent Telemetry Semantic Conventions](https://github.com/agent-telemetry-spec/atsc): Vendor-neutral, OpenTelemetry-compatible semantic conventions for interoperable AI agent observability.
 - [OpenLLMetry](https://github.com/traceloop/openllmetry): OpenTelemetry-based observability for LLM applications and agent workflows.
 - [Multi-agent Observability with OpenTelemetry](https://github.com/chrisipanaque/multi-agent-observability-opentelemetry): OpenTelemetry reference implementation for tracing LangGraph multi-agent systems, including routing decisions, tool calls, LLM invocations, metrics, and OTLP export.
 - [Helicone](https://github.com/Helicone/helicone): Open-source observability platform for LLM usage, latency, cost, caching, and request logs.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,6 +76,7 @@
 - [Ragas](https://github.com/explodinggradients/ragas)：面向 RAG 流水线和 LLM 应用的评估框架。
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix)：面向 LLM、RAG 和机器学习系统的开源可观测与评估平台。
 - [OpenInference](https://github.com/Arize-ai/openinference)：面向 LLM、RAG 和 Agent 应用的 OpenTelemetry 插桩与语义约定。
+- [Agent Telemetry Semantic Conventions](https://github.com/agent-telemetry-spec/atsc)：面向 AI Agent 可观测性的厂商中立、兼容 OpenTelemetry 的语义约定，支持跨工具互操作。
 - [OpenLLMetry](https://github.com/traceloop/openllmetry)：基于 OpenTelemetry 的 LLM 应用和 Agent 工作流可观测性工具。
 - [Multi-agent Observability with OpenTelemetry](https://github.com/chrisipanaque/multi-agent-observability-opentelemetry)：面向 LangGraph 多 Agent 系统的 OpenTelemetry 可观测性参考实现，覆盖路由决策、工具调用、LLM 调用、指标和 OTLP 导出。
 - [Helicone](https://github.com/Helicone/helicone)：开源 LLM 可观测平台，支持用量、延迟、成本、缓存和请求日志分析。


### PR DESCRIPTION
## Summary
Add the Agent Telemetry Semantic Conventions project to the LLM and Agent Observability section in both README language variants.

## Projects or content added
- Agent Telemetry Semantic Conventions (`agent-telemetry-spec/atsc`): vendor-neutral, OpenTelemetry-compatible semantic conventions for interoperable AI agent observability.

## Validation
- Markdown structural checks passed.
- English/Chinese GitHub project URL parity passed.
- `git diff --check` passed.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Self-review: only `README.md` and `README.zh-CN.md` changed; descriptions are semantically aligned.

## Risk
Low: documentation-only addition; the repository is a draft specification, so its conventions may evolve.

## Auto-merge intent
Merge automatically after PR self-review and green or absent checks; do not bypass failing checks.