### PR TITLE
docs: add agentic SAST to AI security operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [nono](https://github.com/nolabs-ai/nono): Zero-setup, least-privilege sandbox for running AI agents and the tools they invoke across macOS, Linux, and Windows WSL2.
 - [Pipelock](https://github.com/luckyPipewrench/pipelock): Open-source AI agent firewall that inspects MCP, A2A, HTTP, and WebSocket egress for prompt injection, SSRF, secret exfiltration, and risky tool-call chains.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar): Security scanner for agentic workflows that visualizes tools and MCP servers and maps discovered vulnerabilities to security frameworks.
+- [agentgg](https://github.com/agentgg-dev/agentgg): Agentic SAST scanner for repository and pull-request diffs, using tool-enabled agents to investigate code paths and turn confirmed findings into reusable detectors.
 - [deepsec](https://github.com/vercel-labs/deepsec): Agent-powered security harness for scanning large codebases, investigating hard-to-find vulnerabilities, and exporting findings for review.
 - [RAG/LLM Security Scanner](https://github.com/olegnazarov/rag-security-scanner): MIT-licensed scanner for testing RAG and LLM applications against prompt injection, data leakage, function abuse, and context manipulation.
 - [Aegis](https://github.com/Justin0504/Aegis): Runtime policy enforcement for AI agents with cryptographic audit trails, human approval gates, and an emergency kill switch.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -701,6 +701,7 @@
 - [nono](https://github.com/nolabs-ai/nono)：零配置、最小权限的 AI Agent 沙箱，可在 macOS、Linux 和 Windows WSL2 上隔离运行 Agent 及其调用的工具。
 - [Pipelock](https://github.com/luckyPipewrench/pipelock)：开源 AI Agent 防火墙，可检查 MCP、A2A、HTTP 和 WebSocket 出站流量，识别 Prompt 注入、SSRF、Secret 泄露和高风险工具调用链。
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar)：面向 Agent 工作流的安全扫描器，可可视化工具与 MCP Server，并将发现的漏洞映射到安全框架。
+- [agentgg](https://github.com/agentgg-dev/agentgg)：面向代码仓库和 Pull Request diff 的 Agentic SAST 扫描器，可通过具备工具调用能力的 Agent 调查代码路径，并将已确认的问题沉淀为可复用检测器。
 - [deepsec](https://github.com/vercel-labs/deepsec)：基于 Agent 的代码安全扫描工具，用于检查大型代码库中的隐蔽漏洞，并导出结果供审查。
 - [RAG/LLM Security Scanner](https://github.com/olegnazarov/rag-security-scanner)：基于 MIT 许可的扫描器，用于测试 RAG 与 LLM 应用中的 Prompt 注入、数据泄露、函数滥用和上下文操纵风险。
 - [Aegis](https://github.com/Justin0504/Aegis)：AI Agent 运行时策略执行工具，提供加密审计轨迹、人机审批门禁和紧急停止开关。


### PR DESCRIPTION
## Summary

- Add agentgg to the Security and Supply Chain section in both README language variants.
- Document its repository and pull-request diff scanning, tool-enabled investigation, and reusable detector workflow.

## Projects or content added

- [agentgg](https://github.com/agentgg-dev/agentgg)

## Validation

- `git diff --check` passed.
- Markdown internal-link, duplicate URL/name, and bilingual parity checks passed.
- Verified the GitHub repository is active, non-archived, Apache-2.0 licensed, and recently updated; current observed star count: 161.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of `HEAD`.
- Diff is limited to `README.md` and `README.zh-CN.md`.

## Risk

Low: documentation-only, one concise entry in an existing category. The project is beta, so future curation should re-check maintenance and scanner quality before expanding coverage.

## Auto-merge intent

Self-review requested; auto-merge only after the expected diff is confirmed and checks are green or absent.
