### PR TITLE
Add SandBase Harness to agentic workflow tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Open-source platforms for building, managing, and querying LLM-powered knowledge
 - [Atmosphere](https://github.com/Atmosphere/atmosphere): Portable JVM agent runtime that unifies model providers and agent frameworks with streaming, tool calls, human approvals, governance, and MCP or A2A support.
 - [Google AX](https://github.com/google/ax): Open-source distributed agent runtime for coordinating agent applications across scalable execution environments.
 - [AgentScope Runtime](https://github.com/agentscope-ai/agentscope-runtime): Production-oriented runtime for agent applications with secure tool sandboxing, Agent-as-a-Service APIs, scalable deployment, and full-stack observability.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness): Self-hosted agent runtime with MCP tools, persistent sessions, approval gates, audit/replay, and backend-selectable execution sandboxes.
 - [Langflow](https://github.com/langflow-ai/langflow): Graphical builder for LangChain-style LLM workflows.
 - [Dify](https://github.com/langgenius/dify): Open-source LLM application development platform with visual agent workflows and AI app deployment.
 - [LangChain](https://github.com/langchain-ai/langchain): Framework for building LLM-powered applications, including agent workflow orchestration.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -462,6 +462,7 @@
 - [Atmosphere](https://github.com/Atmosphere/atmosphere)：面向 JVM 的可移植 Agent 运行时，通过统一接口整合模型提供商和 Agent 框架，并支持流式输出、工具调用、人工审批、治理以及 MCP/A2A。
 - [Google AX](https://github.com/google/ax)：开源分布式 Agent 运行时，用于在可扩展的执行环境中协调 Agent 应用。
 - [AgentScope Runtime](https://github.com/agentscope-ai/agentscope-runtime)：面向生产的 Agent 应用运行时，提供安全工具沙箱、Agent-as-a-Service API、可扩展部署和全栈可观测性。
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness)：可自托管的 Agent 运行时，提供 MCP 工具、持久会话、审批门、审计回放和可选择后端的执行沙箱。
 - [Langflow](https://github.com/langflow-ai/langflow)：LangChain 风格的图形化构建器，支持拖拽式构建 LLM 工作流。
 - [Dify](https://github.com/langgenius/dify)：开源 LLM 应用开发平台，支持可视化 Agent 工作流和 AI 应用部署。
 - [LangChain](https://github.com/langchain-ai/langchain)：构建 LLM 驱动应用的开发框架，支持 Agent 工作流编排。


### PR DESCRIPTION
## Summary
- Add SandBase Harness to the Agentic Workflow section in both English and Chinese README files.
- Keep the description concise and focused on production agent operations: MCP tools, persistent sessions, approvals, audit/replay, and selectable sandbox backends.

## Evidence
- Repository: https://github.com/sandbaseai/sandbase-harness
- Current release: https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8
- Installation: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md
- Backend/security boundary: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/usage.md#sandbox-backends
- `git diff --check` passes.

I maintain/contribute to SandBase Harness and disclose that relationship. The entry is factual; sandbox isolation depends on the selected backend and deployment configuration.
