### PR TITLE
docs: add Zilla to AI infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [Argilla](https://github.com/argilla-io/argilla): Open-source collaboration platform for building, curating, and versioning high-quality datasets for LLM fine-tuning and evaluation.
 - [llmware](https://github.com/llmware-ai/llmware): Unified open-source framework for enterprise LLM applications with integrated RAG, parsing, embedding, and vector database orchestration.
 - [AgentGateway](https://github.com/agentgateway/agentgateway): Next-generation agentic proxy for AI agents and MCP servers, providing secure access, routing, and policy management for agent tool integrations.
+- [Zilla](https://github.com/aklivity/zilla): Lightweight, multi-protocol gateway for event-driven applications and AI agents, governing Kafka, MQTT, APIs, and MCP with shared routing, security, schema, and observability.
 - [Lunar.dev](https://github.com/TheLunarCompany/lunar): Open-source gateway for governing and optimizing third-party API and MCP traffic from applications and AI agents with visibility, policy enforcement, and traffic shaping.
 - [Jarvis Registry](https://github.com/ascending-llc/jarvis-registry): Enterprise MCP and A2A gateway with identity-aware access control, tool discovery, OpenTelemetry tracing, and Prometheus metrics.
 - [Maxun](https://github.com/getmaxun/maxun): Open-source no-code platform for web scraping, crawling, search, and AI data extraction, turning websites into structured APIs for RAG and AI pipelines.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -378,6 +378,7 @@
 - [Argilla](https://github.com/argilla-io/argilla)：面向 AI 工程师和领域专家的开源协作平台，用于构建、管理和版本化 LLM 微调与评估所需的高质量数据集。
 - [llmware](https://github.com/llmware-ai/llmware)：统一的开源框架，用于构建企业级 LLM 应用，集成 RAG、文档解析、嵌入和向量数据库编排能力。
 - [AgentGateway](https://github.com/agentgateway/agentgateway)：面向 AI Agent 和 MCP Server 的新一代代理网关，提供安全访问、路由和策略管理，用于 Agent 工具集成。
+- [Zilla](https://github.com/aklivity/zilla)：面向事件驱动应用和 AI Agent 的轻量级多协议网关，通过统一的路由、安全、Schema 和可观测性治理 Kafka、MQTT、API 与 MCP。
 - [Lunar.dev](https://github.com/TheLunarCompany/lunar)：开源网关，用于治理和优化应用及 AI Agent 的第三方 API 与 MCP 流量，提供流量可见性、策略执行和流量整形能力。
 - [Jarvis Registry](https://github.com/ascending-llc/jarvis-registry)：企业级 MCP 与 A2A 网关，提供身份感知访问控制、工具发现、OpenTelemetry 链路和 Prometheus 指标。
 - [Maxun](https://github.com/getmaxun/maxun)：开源无代码平台，支持 Web 抓取、爬取、搜索和 AI 数据提取，可将网站转化为 RAG 和 AI 流水线所需的结构化 API。


### PR DESCRIPTION
## Summary
- Add Zilla to the AI Infrastructure section in both README language variants.
- Keep the description focused on its operational role as a multi-protocol gateway for AI agents and event-driven systems.

## Projects or content added
- Zilla — https://github.com/aklivity/zilla

## Validation
- Markdown structural checks passed.
- Bilingual GitHub entry parity passed (698 entries).
- `git diff --check` passed.
- Diff limited to README.md and README.zh-CN.md.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.

## Risk
- Documentation-only change; no runtime behavior changes. Zilla capabilities and maturity should be revisited during future curation.

## Auto-merge intent
- Self-review required; merge with squash only after expected diff and checks are green or absent.