### PR TITLE
docs: add agent evaluation and sandboxing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [continuous-eval](https://github.com/relari-ai/continuous-eval): Open-source data-driven evaluation framework for LLM-powered applications, covering retrieval, generation, and end-to-end pipeline quality metrics.
 - [UQLM](https://github.com/cvs-health/uqlm): Apache-2.0 Python package for uncertainty quantification in LLMs, detecting hallucinations and low-confidence outputs in production agent workflows.
 - [APIPark](https://github.com/APIParkLab/APIPark): Cloud-native AI and API gateway for unified LLM provider management, request routing, load balancing, multi-model failover, usage analytics, and API governance.
+- [SaaS-Bench](https://github.com/UniPat-AI/SaaS-Bench): Apache-2.0 benchmark for evaluating computer-use agents on realistic, locally deployable SaaS workflows with state-based task verification.
+- [Inspect Sandboxing Toolkit](https://github.com/UKGovernmentBEIS/aisi-sandboxing): Open-source toolkit for safely running agentic evaluations in isolated Docker, Kubernetes, or Proxmox environments with guidance on tooling, host, and network isolation.
 
 ## AI Serving and Inference Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -246,6 +246,8 @@
 - [continuous-eval](https://github.com/relari-ai/continuous-eval)：开源数据驱动评估框架，面向 LLM 应用提供检索、生成和端到端流水线质量指标。
 - [UQLM](https://github.com/cvs-health/uqlm)：Apache-2.0 许可的 LLM 不确定性量化 Python 包，用于在生产 Agent 工作流中检测幻觉和低置信度输出。
 - [APIPark](https://github.com/APIParkLab/APIPark)：云原生 AI 与 API 网关，提供统一 LLM 提供商管理、请求路由、负载均衡、多模型灾备、用量分析和 API 治理。
+- [SaaS-Bench](https://github.com/UniPat-AI/SaaS-Bench)：基于 Apache-2.0 许可的基准测试工具，用于在可本地部署的真实 SaaS 工作流中评估 computer-use Agent，并通过应用状态验证任务结果。
+- [Inspect Sandboxing Toolkit](https://github.com/UKGovernmentBEIS/aisi-sandboxing)：用于安全运行 Agent 评估的开源工具包，支持 Docker、Kubernetes 和 Proxmox 隔离环境，并提供工具、主机与网络隔离的实践指南。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 


### PR DESCRIPTION
## Summary
- Add two production-oriented agent evaluation resources to both README language variants.
- Keep the entries concise and aligned with the AI operations focus.

## Projects or content added
- SaaS-Bench — realistic, locally deployable SaaS workflows for computer-use agent evaluation with state-based verification.
- Inspect Sandboxing Toolkit — isolated Docker, Kubernetes, and Proxmox environments for safer agentic evaluations.

## Validation
- Markdown structural checks passed: 721 entries and matching URL sets in both README files.
- Duplicate URLs and entry names checked; no duplicates found.
- Internal Markdown links checked.
- `git diff --check` passed.
- Diff limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- GitHub metadata verified: both repositories are not archived; SaaS-Bench is Apache-2.0.

## Risk
- Documentation-only change; no runtime behavior changes.
- Inspect Sandboxing Toolkit was last pushed in 2025-08, so maintenance status should be revisited during future curation.

## Auto-merge intent
- Self-review required; merge with squash only after the expected diff is confirmed and checks are green or absent.
