### PR TITLE
docs: add OpenClaw trace export to agent observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [MCP State Twin](https://github.com/augety121/MCP-State-Twin): Deterministic, forkable, stateful MCP test worlds for reproducible AI agent evaluation without side effects in production systems.
 - [SCALE-CUA](https://github.com/THUDM/SCALE-CUA): Open framework for computer-use agents with verifiable task synthesis, online reinforcement learning, and OSWorld or ScienceBoard evaluation.
 - [ClawLens](https://github.com/nk3750/clawlens): Local OpenClaw observability plugin with tool-call audit logs, risk scoring, live sessions, and operator-controlled guardrails.
+- [Opik OpenClaw](https://github.com/comet-ml/opik-openclaw): OpenClaw plugin that exports agent traces to Opik for monitoring behavior, errors, tokens, and cost.
 - [Opik MCP](https://github.com/comet-ml/opik-mcp): MCP server for reading Opik traces, logging evaluation scores, and managing prompts from AI coding clients.
 - [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay): Multi-language agent runtime and middleware library for managing execution scopes, lifecycle events, and tool or LLM call telemetry.
 - [Kitaru](https://github.com/zenml-io/kitaru): Production AI agent recording and replay toolkit for analyzing runs and improving agent behavior.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,6 +104,7 @@
 - [MCP State Twin](https://github.com/augety121/MCP-State-Twin)：用于可复现 AI Agent 评估的确定性、可分叉、有状态 MCP 测试世界，不会对生产系统产生副作用。
 - [SCALE-CUA](https://github.com/THUDM/SCALE-CUA)：面向计算机使用 Agent 的开源框架，支持可验证任务合成、在线强化学习，以及 OSWorld 和 ScienceBoard 评估。
 - [ClawLens](https://github.com/nk3750/clawlens)：面向 OpenClaw 的本地可观测性插件，提供工具调用审计日志、风险评分、实时会话和由运维人员控制的防护规则。
+- [Opik OpenClaw](https://github.com/comet-ml/opik-openclaw)：将 Agent trace 导出到 Opik 的 OpenClaw 插件，用于监控行为、错误、Token 和成本。
 - [Opik MCP](https://github.com/comet-ml/opik-mcp)：面向 AI 编码客户端的 MCP Server，可读取 Opik trace、记录评估分数并管理 Prompt。
 - [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay)：多语言 Agent 运行时与中间件库，用于管理执行作用域、生命周期事件以及工具或 LLM 调用遥测。
 - [Kitaru](https://github.com/zenml-io/kitaru)：面向生产环境的 AI Agent 录制与回放工具，用于分析运行过程并改进 Agent 行为。


### PR DESCRIPTION
## Summary
- Add OpenClaw trace export coverage to the LLM and Agent Observability section.
- Keep the English and Simplified Chinese README entries semantically aligned.

## Projects or content added
- Opik OpenClaw — https://github.com/comet-ml/opik-openclaw

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, and duplicate entry names.
- Bilingual URL parity passed for the new project.
- `git diff --check` passed.
- Diff limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.

## Risk
- Documentation-only change; no runtime behavior changes. The plugin's compatibility and exported telemetry should be revisited as Opik and OpenClaw evolve.

## Auto-merge intent
- Self-review the full diff and merge with squash only if the expected files are changed and checks are green or absent.
