### PR TITLE
docs: add agent evaluation, inference benchmark, and agent runtime security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [APIPark](https://github.com/APIParkLab/APIPark): Cloud-native AI and API gateway for unified LLM provider management, request routing, load balancing, multi-model failover, usage analytics, and API governance.
 - [SaaS-Bench](https://github.com/UniPat-AI/SaaS-Bench): Apache-2.0 benchmark for evaluating computer-use agents on realistic, locally deployable SaaS workflows with state-based task verification.
 - [Inspect Sandboxing Toolkit](https://github.com/UKGovernmentBEIS/aisi-sandboxing): Open-source toolkit for safely running agentic evaluations in isolated Docker, Kubernetes, or Proxmox environments with guidance on tooling, host, and network isolation.
+- [Any Agent](https://github.com/mozilla-ai/any-agent): Apache-2.0 framework providing a single interface to use and evaluate different agent frameworks across standardized benchmarks.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench): Apache-2.0 benchmark for evaluating browser AI agents on everyday real-world tasks with reproducible evaluation workflows.
 
 ## AI Serving and Inference Operations
 
@@ -312,6 +314,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [NVIDIA NVCF](https://github.com/NVIDIA/nvcf): Platform for deploying and routing GPU-accelerated inference, streaming, and batch workloads at scale.
 - [Grove](https://github.com/ai-dynamo/grove): Kubernetes enhancements for topology-aware gang scheduling and autoscaling of distributed AI workloads.
 - [Cube Studio](https://github.com/data-infra/cube-studio): Cloud-native AI platform for Kubernetes with MLOps workflows, distributed training, GPU virtualization, inference serving, and LLMOps capabilities.
+- [InferenceX](https://github.com/SemiAnalysisAI/InferenceX): Open-source continuous inference benchmark platform for comparing LLM serving performance across hardware including GB200, MI355X, B200, and Ascend.
 
 ## AIOps
 
@@ -333,6 +336,7 @@ Tools for deploying, scaling, routing, and operating AI model inference workload
 - [Nudgebee](https://github.com/nudgebee/nudgebee): Open-source SRE copilot for Kubernetes and major clouds, combining observability, FinOps, runbook automation, incident response, and ChatOps workflows.
 - [AIOpsLab](https://github.com/microsoft/AIOpsLab): Holistic framework for designing, developing, and evaluating autonomous AIOps agents against reproducible operations scenarios.
 - [SREGym](https://github.com/SREGym/SREGym): Benchmark and experimentation framework for evaluating whether AI agents can diagnose and resolve production incidents in reproducible SRE environments.
+- [ANOLISA](https://github.com/alibaba/anolisa): Agentic OS with runtime, security, observability, and tokenless response compression for lowering token usage and cost in production AI agent deployments.
 
 ## AI Infrastructure
 
@@ -692,6 +696,7 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [Agent3σ-Canary](https://github.com/antgroup/Agent3Sigma-Canary): Sandboxed framework for evaluating AI agent security in realistic tool-using workflows, with trajectory-based scoring across safety, awareness, and task utility.
 - [AgentDojo](https://github.com/ethz-spylab/agentdojo): Dynamic environment for evaluating attacks and defenses against LLM agents in realistic tool-use workflows.
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Toolkit for policy enforcement, zero-trust identity, execution sandboxing, and reliability engineering for autonomous AI agents.
+- [Prismor](https://github.com/PrismorSec/prismor): Self-hosted runtime control plane for AI agents that observes, approves, or blocks rogue tool calls before execution, covering secret leaks, prompt injection, and supply-chain risks.
 - [PyRIT](https://github.com/microsoft/PyRIT): Open-source framework for proactively identifying and testing generative AI risks through configurable red-team attack strategies.
 - [Open Agent Auth](https://github.com/alibaba/open-agent-auth): Enterprise framework for agent-operation authorization with cryptographic identity binding, fine-grained permissions, and semantic audit trails.
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector): Security scanner for AI agent skills that detects vulnerabilities, malicious patterns, and other security risks.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -249,6 +249,8 @@
 - [APIPark](https://github.com/APIParkLab/APIPark)：云原生 AI 与 API 网关，提供统一 LLM 提供商管理、请求路由、负载均衡、多模型灾备、用量分析和 API 治理。
 - [SaaS-Bench](https://github.com/UniPat-AI/SaaS-Bench)：基于 Apache-2.0 许可的基准测试工具，用于在可本地部署的真实 SaaS 工作流中评估 computer-use Agent，并通过应用状态验证任务结果。
 - [Inspect Sandboxing Toolkit](https://github.com/UKGovernmentBEIS/aisi-sandboxing)：用于安全运行 Agent 评估的开源工具包，支持 Docker、Kubernetes 和 Proxmox 隔离环境，并提供工具、主机与网络隔离的实践指南。
+- [Any Agent](https://github.com/mozilla-ai/any-agent)：Apache-2.0 许可的框架，提供统一接口来使用和评估不同 Agent 框架，支持标准化基准测试。
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench)：Apache-2.0 许可的基准测试工具，用于在真实日常任务上评估浏览器 AI Agent，提供可复现的评估工作流。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 
@@ -312,6 +314,7 @@
 - [NVIDIA NVCF](https://github.com/NVIDIA/nvcf)：用于大规模部署和路由 GPU 加速推理、流式处理及批处理工作负载的平台。
 - [Grove](https://github.com/ai-dynamo/grove)：面向分布式 AI 工作负载的 Kubernetes 增强组件，支持拓扑感知的 Gang 调度和自动扩缩容。
 - [Cube Studio](https://github.com/data-infra/cube-studio)：面向 Kubernetes 的云原生 AI 平台，提供 MLOps 工作流、分布式训练、GPU 虚拟化、推理服务和 LLMOps 能力。
+- [InferenceX](https://github.com/SemiAnalysisAI/InferenceX)：开源持续推理基准平台，用于跨 GB200、MI355X、B200 和 Ascend 等硬件对比 LLM 服务性能。
 
 ## AIOps 智能运维
 
@@ -333,6 +336,7 @@
 - [Nudgebee](https://github.com/nudgebee/nudgebee)：面向 Kubernetes 和主流云平台的开源 SRE Copilot，整合可观测性、FinOps、Runbook 自动化、事件响应和 ChatOps 工作流。
 - [AIOpsLab](https://github.com/microsoft/AIOpsLab)：用于设计、开发和评估自主 AIOps Agent 的综合框架，支持在可复现场景中验证运维能力。
 - [SREGym](https://github.com/SREGym/SREGym)：用于评估 AI Agent 能否在可复现 SRE 环境中诊断并解决生产事故的基准测试与实验框架。
+- [ANOLISA](https://github.com/alibaba/anolisa)：Agentic OS，提供运行时、安全、可观测性和无 Token 响应压缩能力，用于降低生产 AI Agent 部署的 Token 用量和成本。
 
 ## AI 基础设施
 
@@ -692,6 +696,7 @@
 - [Agent3σ-Canary](https://github.com/antgroup/Agent3Sigma-Canary)：在沙箱化真实工具工作流中评估 AI Agent 安全性的框架，基于完整执行轨迹从安全结果、安全意识和任务效用等维度评分。
 - [AgentDojo](https://github.com/ethz-spylab/agentdojo)：用于在真实工具调用工作流中评估 LLM Agent 攻击与防御能力的动态环境。
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)：用于自主 AI Agent 的策略执行、零信任身份、执行沙箱和可靠性工程工具包。
+- [Prismor](https://github.com/PrismorSec/prismor)：可自托管的 AI Agent 运行时控制平面，可在执行前观察、审批或拦截恶意工具调用，覆盖 Secret 泄露、Prompt 注入和供应链风险。
 - [PyRIT](https://github.com/microsoft/PyRIT)：开源生成式 AI 风险识别框架，通过可配置的红队攻击策略主动发现和测试 AI 系统风险。
 - [Open Agent Auth](https://github.com/alibaba/open-agent-auth)：企业级 Agent 操作授权框架，支持加密身份绑定、细粒度权限和语义审计轨迹。
 - [SkillSpector](https://github.com/NVIDIA/SkillSpector)：AI Agent Skill 安全扫描器，用于检测漏洞、恶意模式和其他安全风险。


### PR DESCRIPTION
## Summary

- Add 5 new entries across LLM and Agent Observability, AI Serving and Inference Operations, AIOps, and Security and Supply Chain sections.
- All entries added to both README.md and README.zh-CN.md with equivalent bilingual descriptions.

## Projects or content added

- [Any Agent](https://github.com/mozilla-ai/any-agent) — Apache-2.0 framework providing a single interface to use and evaluate different agent frameworks. Stars: 1200. Added to LLM and Agent Observability.
- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) — Apache-2.0 benchmark for evaluating browser AI agents on everyday real-world tasks. Stars: 640. Added to LLM and Agent Observability.
- [InferenceX](https://github.com/SemiAnalysisAI/InferenceX) — Open-source continuous inference benchmark platform for comparing LLM serving performance across hardware (GB200, MI355X, B200, Ascend). Stars: 1619. Added to AI Serving and Inference Operations.
- [ANOLISA](https://github.com/alibaba/anolisa) — Agentic OS with runtime, security, observability, and tokenless response compression for lowering token usage and cost. Stars: 617. Added to AIOps.
- [Prismor](https://github.com/PrismorSec/prismor) — Self-hosted runtime control plane for AI agents that observes, approves, or blocks rogue tool calls before execution. Stars: 338. Added to Security and Supply Chain.

## Validation

- Markdown structural checks passed (internal links, duplicate URLs, duplicate entry names).
- `git diff --check` passed.
- Bilingual entries are semantically aligned between README.md and README.zh-CN.md.
- Diff limited to README.md and README.zh-CN.md (10 insertions, 0 deletions).
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.

## Risk

- Documentation-only change; no runtime behavior changes.
- ANOLISA is a relatively new project (617 stars) but backed by Alibaba with active maintenance and Apache-2.0 license.
- Prismor is a newer project (338 stars) but actively maintained with Apache-2.0 license and clear production-oriented runtime control plane scope.

## Auto-merge intent

- Self-review completed; diff is expected and limited to README files.
- Merge with squash after checks are green or absent.