### PR TITLE
docs: add RAG Arena to evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Agents Observe](https://github.com/simple10/agents-observe): Real-time observability dashboard for Claude Code and Codex agents with session replay, filtering, and token usage statistics.
 - [Pi Agent Observability](https://github.com/disler/pi-agent-observability): Local observability stack for the Pi coding agent, streaming turns, tool calls, model changes, and token-cost telemetry into a dashboard for replay and comparison.
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval): Open-source RAG evaluation toolkit for measuring retrieval and answer quality without requiring golden answers.
+- [RAG Arena](https://github.com/firecrawl/rag-arena): Open-source RAG evaluation workflow that uses user feedback to compare answer quality and improve retrieval systems.
 - [Axon](https://github.com/langchain-tracer/Axon): OpenTelemetry-native LLM observability CLI for viewing LLM and agent traces in real time.
 - [EvalScope](https://github.com/modelscope/evalscope): LLM evaluation framework for capability benchmarks, agent-loop evaluation with recorded traces, inference performance testing, and interactive result analysis.
 - [Kiln](https://github.com/Kiln-AI/kiln): Open-source workbench for building and improving AI systems with collaborative evals, prompt optimization, RAG, agents, synthetic data, and production deployment support.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,6 +201,7 @@
 - [Agents Observe](https://github.com/simple10/agents-observe)：Claude Code 和 Codex Agent 的实时可观测仪表盘，支持会话回放、过滤和 Token 用量统计。
 - [Pi Agent Observability](https://github.com/disler/pi-agent-observability)：面向 Pi 编码 Agent 的本地可观测性栈，将每轮执行、工具调用、模型变更及 Token 成本遥测流入仪表盘，支持回放和对比。
 - [Open RAG Eval](https://github.com/vectara/open-rag-eval)：开源 RAG 评估工具包，无需预先准备标准答案即可衡量检索和回答质量。
+- [RAG Arena](https://github.com/firecrawl/rag-arena)：基于用户反馈的开源 RAG 评估工作流，用于比较回答质量并改进检索系统。
 - [Axon](https://github.com/langchain-tracer/Axon)：基于 OpenTelemetry 的 LLM 可观测性 CLI，可实时查看 LLM 和 Agent 链路。
 - [EvalScope](https://github.com/modelscope/evalscope)：LLM 评估框架，支持能力基准测试、带 trace 记录的 Agent Loop 评估、推理性能测试和交互式结果分析。
 - [Kiln](https://github.com/Kiln-AI/kiln)：用于构建和改进 AI 系统的开源工作台，支持协作式评估、Prompt 优化、RAG、Agent、合成数据和生产部署。


### PR DESCRIPTION
## Summary
- Add RAG Arena to the LLM and Agent Observability section in both README language variants.

## Projects or content added
- RAG Arena — https://github.com/firecrawl/rag-arena
- Verified repository: 223 stars, MIT license, not archived; last push 2024-04-14.

## Validation
- Markdown internal-link, duplicate URL/name, and bilingual URL-parity checks passed (724 URLs).
- `git diff --check` passed.
- Diff limited to README.md and README.zh-CN.md.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.

## Risk
- Documentation-only change; no runtime behavior changes. RAG Arena has no recent commits after 2024-04-14, so maintenance status should be revisited in future curation.

## Auto-merge intent
- Self-review required; merge with squash only after expected diff is confirmed and checks are green or absent.