### PR TITLE
[codex] add agent-watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [Inspect Sandboxing Toolkit](https://github.com/UKGovernmentBEIS/aisi-sandboxing): Open-source toolkit for safely running agentic evaluations in isolated Docker, Kubernetes, or Proxmox environments with guidance on tooling, host, and network isolation.
 - [Any Agent](https://github.com/mozilla-ai/any-agent): Apache-2.0 framework providing a single interface to use and evaluate different agent frameworks across standardized benchmarks.
 - [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench): Apache-2.0 benchmark for evaluating browser AI agents on everyday real-world tasks with reproducible evaluation workflows.
+- [agent-watch](https://github.com/soul-sol/agent-watch): POSIX shell scripts for classifying background coding-agent runs and distinguishing transport failures from authentication failures before launch.
 
 ## AI Serving and Inference Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -252,6 +252,7 @@
 - [Inspect Sandboxing Toolkit](https://github.com/UKGovernmentBEIS/aisi-sandboxing)：用于安全运行 Agent 评估的开源工具包，支持 Docker、Kubernetes 和 Proxmox 隔离环境，并提供工具、主机与网络隔离的实践指南。
 - [Any Agent](https://github.com/mozilla-ai/any-agent)：Apache-2.0 许可的框架，提供统一接口来使用和评估不同 Agent 框架，支持标准化基准测试。
 - [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench)：Apache-2.0 许可的基准测试工具，用于在真实日常任务上评估浏览器 AI Agent，提供可复现的评估工作流。
+- [agent-watch](https://github.com/soul-sol/agent-watch)：用于监控后台编码 Agent 任务的 POSIX Shell 脚本，可判定 RUNNING、DONE、FAILED、STALL，并在启动前区分传输故障与身份验证故障。
 
 ## AI Serving and Inference Operations AI 推理服务运维
 


### PR DESCRIPTION
## Summary

- Add agent-watch to LLM and Agent Observability.
- Keep the English and Chinese lists synchronized.

## Problem and effect

Background coding-agent runs may finish, fail, or stall without a clear operator signal. The list did not include a compact POSIX-shell option for process-level agent monitoring and pre-launch failure classification.

## Root cause and fix

Agent execution state and launch-path failures require different checks. agent-watch classifies background runs as RUNNING, DONE, FAILED, or STALL and distinguishes transport from authentication failures before launch. This PR adds the same project to the matching section in both language files.

## Fit and sources

- Scope: production operations for LLM and agent systems, specifically observability.
- Source: https://github.com/soul-sol/agent-watch
- v0.2.0: https://github.com/soul-sol/agent-watch/releases/tag/v0.2.0
- v0.3.0: https://github.com/soul-sol/agent-watch/releases/tag/v0.3.0
- License: MIT license file in the source repository.

## Validation

- Confirmed the repository and both releases directly.
- Added to the bottom of the matching category in README.md and README.zh-CN.md, following the existing non-alphabetical order.
- git diff --check passes.
- Repository-wide awesome-lint reports pre-existing formatting issues outside this two-line change.