### PR TITLE
docs: add GPT-Load to AI gateway tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Tools for tracing, evaluating, debugging, and operating LLM, RAG, and agent appl
 - [continuous-eval](https://github.com/relari-ai/continuous-eval): Open-source data-driven evaluation framework for LLM-powered applications, covering retrieval, generation, and end-to-end pipeline quality metrics.
 - [UQLM](https://github.com/cvs-health/uqlm): Apache-2.0 Python package for uncertainty quantification in LLMs, detecting hallucinations and low-confidence outputs in production agent workflows.
 - [APIPark](https://github.com/APIParkLab/APIPark): Cloud-native AI and API gateway for unified LLM provider management, request routing, load balancing, multi-model failover, usage analytics, and API governance.
+- [GPT-Load](https://github.com/tbphp/gpt-load): Self-hosted AI gateway for consolidating multi-channel credentials behind one endpoint, with scheduling, failover, request logs, and usage accounting.
 - [SaaS-Bench](https://github.com/UniPat-AI/SaaS-Bench): Apache-2.0 benchmark for evaluating computer-use agents on realistic, locally deployable SaaS workflows with state-based task verification.
 - [Inspect Sandboxing Toolkit](https://github.com/UKGovernmentBEIS/aisi-sandboxing): Open-source toolkit for safely running agentic evaluations in isolated Docker, Kubernetes, or Proxmox environments with guidance on tooling, host, and network isolation.
 - [Any Agent](https://github.com/mozilla-ai/any-agent): Apache-2.0 framework providing a single interface to use and evaluate different agent frameworks across standardized benchmarks.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -248,6 +248,7 @@
 - [continuous-eval](https://github.com/relari-ai/continuous-eval)：开源数据驱动评估框架，面向 LLM 应用提供检索、生成和端到端流水线质量指标。
 - [UQLM](https://github.com/cvs-health/uqlm)：Apache-2.0 许可的 LLM 不确定性量化 Python 包，用于在生产 Agent 工作流中检测幻觉和低置信度输出。
 - [APIPark](https://github.com/APIParkLab/APIPark)：云原生 AI 与 API 网关，提供统一 LLM 提供商管理、请求路由、负载均衡、多模型灾备、用量分析和 API 治理。
+- [GPT-Load](https://github.com/tbphp/gpt-load)：自托管 AI 网关，将多渠道凭据统一到一个端点，并提供调度、故障转移、请求日志和用量统计。
 - [SaaS-Bench](https://github.com/UniPat-AI/SaaS-Bench)：基于 Apache-2.0 许可的基准测试工具，用于在可本地部署的真实 SaaS 工作流中评估 computer-use Agent，并通过应用状态验证任务结果。
 - [Inspect Sandboxing Toolkit](https://github.com/UKGovernmentBEIS/aisi-sandboxing)：用于安全运行 Agent 评估的开源工具包，支持 Docker、Kubernetes 和 Proxmox 隔离环境，并提供工具、主机与网络隔离的实践指南。
 - [Any Agent](https://github.com/mozilla-ai/any-agent)：Apache-2.0 许可的框架，提供统一接口来使用和评估不同 Agent 框架，支持标准化基准测试。


### PR DESCRIPTION
## Summary
- Add GPT-Load to the AI gateway curation section in both README language variants.
- Keep the entry focused on multi-channel credential management, scheduling, failover, logs, and usage accounting.

## Projects or content added
- GPT-Load — https://github.com/tbphp/gpt-load
- Verified repository: MIT license, active non-archived repository, 6,548 GitHub stars at discovery time, and release `v2.0.0-rc.5` published 2026-09-04.

## Validation
- Markdown structural checks passed: internal links, duplicate URLs, duplicate entry names.
- English and Chinese GitHub entry sets match (708 entries).
- `git diff --check` passed.
- Diff limited to `README.md` and `README.zh-CN.md`.
- Rebased onto latest `origin/main`; `origin/main` is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.
- Auto-merge self-review: pending PR diff/check review.

## Risk
- Documentation-only change; no runtime behavior changes.
- GPT-Load is currently on a release candidate, so future curation should re-check release stability and compatibility before recommending it for production.

## Auto-merge intent
- Self-review the full diff and merge with squash only when the diff is expected and checks are green or absent.
