### PR TITLE
docs: add MCPHub to agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Infrastructure for web crawling, AI-ready extraction, search intelligence, and R
 - [OpenKruise Agents](https://github.com/openkruise/agents): Kubernetes operator and best-practice guide for rapid, cost-effective agent sandbox lifecycle management at scale.
 - [ArtifactFS](https://github.com/cloudflare/artifact-fs): FUSE filesystem driver that mounts large git repos instantly with on-demand hydration, eliminating clone latency for agents, sandboxes, and containers.
 - [Docker Compose for Agents](https://github.com/docker/compose-for-agents): Docker Compose examples for running open-source LLMs, tools, and agent runtimes as reproducible local or deployment workflows.
+- [MCPHub](https://github.com/samanhappy/mcphub): Self-hosted MCP gateway and management platform with unified endpoints, access control, health checks, routing, logs, and hot-swappable server configuration.
 
 ## LLM Knowledge
 
@@ -719,7 +720,6 @@ Streaming systems provide the event transport and analytics foundation for telem
 - [Varlock](https://github.com/dmno-dev/varlock): AI-safe environment variable format that separates machine-readable schemas for agents from human-readable secrets, preventing accidental credential exposure in agent configs.
 - [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner): Security scanner for MCP servers that identifies potential threats and security findings before agents depend on their tool integrations.
 - [OctoBus](https://github.com/chaitin/OctoBus): Local single-binary gateway for managing pluggable services and exposing selected capabilities through gRPC, Connect RPC, and MCP.
-- [yoloAI](https://github.com/kstenerud/yoloai): Sandboxed runner for AI coding agents with disposable project copies, controlled credentials and network access, reviewable diffs, and selectable isolation backends.
 - [Sandbox0](https://github.com/sandbox0-ai/sandbox0): Kubernetes-native runtime for persistent, encrypted AI-agent sandboxes with durable rootfs checkpoints, gVisor support, and separated storage and compute.
 - [OpenHack](https://github.com/openhackai/OpenHack): Open-source agentic security scanner and verifier for finding and validating vulnerabilities in codebases with open-source models.
 - [AgentStalker](https://github.com/Gach0ng/AgentStalker): End-to-end LLM agent security audit framework combining static modeling, attack synthesis, sandbox replay, MCP auditing, and evidence-backed reports.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -423,6 +423,7 @@
 - [OpenKruise Agents](https://github.com/openkruise/agents)：Kubernetes Operator 与最佳实践指南，用于大规模、快速且低成本的 Agent 沙箱生命周期管理。
 - [ArtifactFS](https://github.com/cloudflare/artifact-fs)：FUSE 文件系统驱动，可即时挂载大型 Git 仓库并按需加载文件内容，消除 Agent、沙箱和容器的克隆延迟。
 - [Docker Compose for Agents](https://github.com/docker/compose-for-agents)：使用 Docker Compose 运行开源 LLM、工具和 Agent 运行时的示例集合，便于构建可复现的本地或部署工作流。
+- [MCPHub](https://github.com/samanhappy/mcphub)：可自托管的 MCP 网关与管理平台，提供统一端点、访问控制、健康检查、路由、日志和无需停机的 Server 配置更新。
 
 ## LLM 知识库
 
@@ -719,7 +720,6 @@
 - [Varlock](https://github.com/dmno-dev/varlock)：AI 安全的环境变量格式，将面向 Agent 的机器可读 Schema 与面向人类的 Secret 分离，防止 Agent 配置中的凭据意外泄露。
 - [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner)：MCP Server 安全扫描器，可在 Agent 依赖工具集成前识别潜在威胁和安全问题。
 - [OctoBus](https://github.com/chaitin/OctoBus)：本地单二进制网关，用于管理可插拔服务，并通过 gRPC、Connect RPC 和 MCP 暴露选定能力。
-- [yoloAI](https://github.com/kstenerud/yoloai)：面向 AI 编码 Agent 的沙箱运行器，提供项目副本隔离、受控凭据与网络访问、可审查 diff，以及可选的隔离后端。
 - [Sandbox0](https://github.com/sandbox0-ai/sandbox0)：Kubernetes 原生的持久化加密 AI Agent 沙箱运行时，支持持久 rootfs checkpoint、gVisor，以及存储与计算分离。
 - [OpenHack](https://github.com/openhackai/OpenHack)：开源 Agent 安全扫描与验证工具，使用开源模型在代码库中发现并验证安全漏洞。
 - [AgentStalker](https://github.com/Gach0ng/AgentStalker)：端到端 LLM Agent 安全审计框架，结合静态建模、攻击合成、沙箱回放、MCP 审计和基于证据的报告。


### PR DESCRIPTION
## Summary
- Add MCPHub to the agent infrastructure catalog in both README language variants.
- Keep the entry focused on self-hosted MCP gateway operations and management.

## Projects or content added
- MCPHub — https://github.com/samanhappy/mcphub

## Validation
- Verified the repository is active, non-archived, Apache-2.0 licensed, and has a recent release (v1.0.34).
- Markdown structural, duplicate URL/name, and bilingual URL parity checks passed.
- `git diff --check` passed.
- Diff limited to README.md and README.zh-CN.md.
- Rebased onto latest origin/main; origin/main is an ancestor of HEAD.
- Remote branch SHA verified against local HEAD.

## Risk
- Documentation-only change. MCPHub's operational behavior and security posture still depend on deployment configuration and should be revisited during future curation.

## Auto-merge intent
- Self-review the full diff and merge with squash only if the diff is expected and checks are green or absent.